### PR TITLE
fix(package): fixes handling for wrong name

### DIFF
--- a/riocli/package/util.py
+++ b/riocli/package/util.py
@@ -58,6 +58,10 @@ def get_package_name(client: Client, guid: str) -> str:
 
 def find_package_guid(client: Client, name: str, version: str = None) -> str:
     packages = client.get_all_packages(name=name, version=version)
+    if len(packages) == 0:
+        click.secho("package not found", fg='red')
+        exit(1)
+
     if len(packages) == 1:
         return packages[0].packageId
 


### PR DESCRIPTION
The @name_to_guid decorator didn't handle the case when valid package
is not found based on the name. This commit fixes the behaviour by
erroring out explicitly.