### PR TITLE
Feature/enable plugins

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ riocli = {path = "."}
 click-spinner = "==0.1.10"
 click-help-colors = "==0.9.1"
 click-repl = "==0.2.0"
+click-plugins = "==1.1.1"
 click = "==8.0.1"
 rapyuta-io = "==0.32.0"
 pyyaml = "==5.4.1"

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -18,7 +18,9 @@ __version__ = "0.2.0"
 import click
 import rapyuta_io.version
 from click_help_colors import HelpColorsGroup
+from click_plugins import with_plugins
 from click_repl import register_repl
+from pkg_resources import iter_entry_points
 
 from riocli.auth import auth
 from riocli.build import build
@@ -34,6 +36,7 @@ from riocli.secret import secret
 from riocli.static_route import static_route
 
 
+@with_plugins(iter_entry_points('riocli.plugins'))
 @click.group(
     invoke_without_command=False,
     cls=HelpColorsGroup,

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "click-completion==0.5.2",
         "click-help-colors==0.9.1",
         "click-repl==0.2.0",
+        "click-plugins==1.1.1",
         "click-spinner==0.1.10",
         "concurrencytest==0.1.2",
         "enum34==1.1.6",


### PR DESCRIPTION
What's been added
1. Click has a system for extending the CLI with plugins. To enable that, an annotation on the main driver script was added.

Improvements
1. Lets discuss if we can host user added scripts in root, or home them in  something like "rio contrib xxx"