### PR TITLE
fix(network): makes device flag optional

### DIFF
--- a/riocli/device/util.py
+++ b/riocli/device/util.py
@@ -33,6 +33,12 @@ def name_to_guid(f: typing.Callable) -> typing.Callable:
             exit(1)
 
         name = kwargs.pop('device_name')
+
+        # device_name is not specified
+        if name is None:
+            f(**kwargs)
+            return
+
         guid = None
 
         if is_valid_uuid(name):


### PR DESCRIPTION
The device_name_to_guid decorator only worked if device_name is present.
This assumption is correct for all the device sub-commands where
device_name is the argument.

In Network though, device_name is only required for device networks. So,
this commit adds the check to name device_name optional in the
decorator.