### PR TITLE
[Bugfix] Can't login with a different account after overwriting the config

### DIFF
--- a/riocli/config/config.py
+++ b/riocli/config/config.py
@@ -73,6 +73,9 @@ class Configuration(object):
         if with_project and project is None:
             raise NoProjectSelected
 
+        if not with_project:
+            project = None
+
         return Client(auth_token=token, project=project)
 
     def get_auth_header(self) -> dict:


### PR DESCRIPTION
When `new_client` function was called with `with_project=False`, it could still read project_id from the config file. So, if first user is part of a Project but second user (second login) is not, it can raise an exception.

This issue is fixed in this commit.

Resolves https://github.com/rapyuta-robotics/rapyuta-io-cli/issues/49



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=974446537)
