### PR TITLE
fix: typo in maximum memory limit

### DIFF
--- a/jsonschema/package-schema.yaml
+++ b/jsonschema/package-schema.yaml
@@ -183,7 +183,7 @@ definitions:
           memory:
             type: number
             min: 256
-            max: 32678
+            max: 32768
     required:
       - type
     dependencies:


### PR DESCRIPTION
* This PR updates the maximum memory value from 32678 MiB to 32768 MiB, which is the correct conversion from 32 GiB

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1000402149)
┆Link To Task: https://www.wrike.com/open.htm?id=1000402149
