### PR TITLE
fix(deployment): speed up  `deployment list` command

### DIFF
--- a/riocli/deployment/list.py
+++ b/riocli/deployment/list.py
@@ -42,11 +42,9 @@ def list_deployments(device: str, phase: typing.List[str]) -> None:
 
 def display_deployment_list(deployments: typing.List[Deployment], show_header: bool = True):
     if show_header:
-        click.secho('{:29} {:<25} {:<24} {:40}'.format('Deployment ID', 'Name', 'Phase', 'Package Name'), fg='yellow')
+        click.secho('{:29} {:<25} {:<24} {:40}'.format('Deployment ID', 'Name', 'Phase', 'Package'), fg='yellow')
 
     for deployment in deployments:
-        if deployment.is_partial:
-            deployment.refresh()
-
+        package_name_version = "{} ({})".format(deployment.packageName, deployment.packageVersion)
         click.secho('{:29} {:<25} {:<24} {:40}'.format(deployment.deploymentId, deployment.name,
-                                                       deployment.phase, deployment.packageName))
+                                                       deployment.phase, package_name_version))


### PR DESCRIPTION
### Description
The `rio deployment list` command tries to fetch the details for every deployment and thus consumes a lot of time before completion. We can omit the call since we only want to display a subset of already available attributes in the list call.

```bash
→ time pipenv run python -m riocli deployment list
Deployment ID                 Name                      Phase                    Package Name                           
dep-clchucunvejlwdpemabnpyqh  testing                   Succeeded                publisher_subscriber_invento           
dep-lafnewlqhcigvvspyedsvhdu  mongo-dev                 Succeeded                Mongo Cloud                            
dep-woctporbpcaatumpkcchsxyw  redis-cloud               Succeeded                Redis Cloud                            
dep-tjzgwpmsqkbjkmsygfklywun  clearml-webserver-dev     Succeeded                ClearML Webserver                      
dep-rfbnvxymoxjlvtvvbcvperqh  clearml-dev               Succeeded                ClearML Cloud                          
dep-netjdwalcsguwlnofintigln  redis-dev                 Succeeded                Redis Cloud                            
dep-ahestnacgrzmpnctygsoxiti  elastic-dev               Succeeded                Elastic Cloud                          
dep-imsrnwaywpdafkyshzfzvtdg  invento_demo_dep          Succeeded                publisher_subscriber_invento           
dep-ramrbvaqbceowomqoxkgwcjz  dep2                      Succeeded                busyboxros                             

real    0m30.567s
user    0m2.220s
sys     0m0.129s
```

### Testing


```bash
→ time pipenv run python -m riocli deployment list
Deployment ID                 Name                      Phase                    Package                                
dep-clchucunvejlwdpemabnpyqh  testing                   Succeeded                publisher_subscriber_invento (v1.0.3)  
dep-lafnewlqhcigvvspyedsvhdu  mongo-dev                 Succeeded                Mongo Cloud (1.0.0)                    
dep-woctporbpcaatumpkcchsxyw  redis-cloud               Succeeded                Redis Cloud (1.0.0)                    
dep-tjzgwpmsqkbjkmsygfklywun  clearml-webserver-dev     Succeeded                ClearML Webserver (1.0.0)              
dep-rfbnvxymoxjlvtvvbcvperqh  clearml-dev               Succeeded                ClearML Cloud (1.0.0)                  
dep-netjdwalcsguwlnofintigln  redis-dev                 Succeeded                Redis Cloud (1.0.0)                    
dep-ahestnacgrzmpnctygsoxiti  elastic-dev               Succeeded                Elastic Cloud (1.0.0)                  
dep-imsrnwaywpdafkyshzfzvtdg  invento_demo_dep          Succeeded                publisher_subscriber_invento (v1.0.2)  
dep-ramrbvaqbceowomqoxkgwcjz  dep2                      Succeeded                busyboxros (v1.0.1)                    

real    0m2.501s
user    0m1.277s
sys     0m0.125s
```

### Bonus
Now that we have package version in the list deployments response, we can display it in the output.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1030101835)
