### PR TITLE
feat(network): adds support for fractional resource limits 

### DIFF
--- a/jsonschema/network-schema.yaml
+++ b/jsonschema/network-schema.yaml
@@ -60,12 +60,6 @@ definitions:
               - deviceGUID
               - networkInterface
 
-  resourceLimits:
-    enum:
-      - xSmall
-      - small
-      - medium
-      - large
   rosDistro:
     enum:
       - melodic
@@ -113,3 +107,16 @@ definitions:
   uuid:
     type: string
     pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+
+  resourceLimits:
+    type: object
+    properties:
+      cpu:
+        type: number
+        multipleOf: 0.025
+      memory:
+        type: number
+        multipleOf: 128
+    required:
+    - cpu
+    - memory

--- a/riocli/apply/manifests/11-cloud-native-network.yaml
+++ b/riocli/apply/manifests/11-cloud-native-network.yaml
@@ -6,4 +6,6 @@ spec:
   runtime: "cloud"
   type: "native"
   rosDistro: "melodic"
-  resourceLimits: "xSmall"
+  resourceLimits:
+    cpu: 0.5
+    memory: 1024

--- a/riocli/network/create.py
+++ b/riocli/network/create.py
@@ -27,9 +27,8 @@ from riocli.network.routed_network import create_routed_network
 @click.option('--ros', help='Version of ROS',
               type=click.Choice(['kinetic', 'melodic', 'noetic']), default='melodic')
 @click.option('--device', 'device_name', help='Device ID of the Device where Network will run (device only)')
-@click.option('--limit', help='Resource Limit for Network (cloud only) '
-                              '[x_small is only available for Native Network]',
-              type=click.Choice(['x_small', 'small', 'medium', 'large']), default='small')
+@click.option('--cpu', help='cpu limit for Network (cloud only) ', type=float)
+@click.option('--memory', help='memory limit for Network (cloud only) ', type=int)
 @click.option('--network-interface', '-nic', type=str,
               help='Network Interface on which Network will listen (device only)')
 @click.option('--restart-policy', help='Restart policy for the Network (device only)',

--- a/riocli/network/model.py
+++ b/riocli/network/model.py
@@ -15,10 +15,8 @@ import typing
 from typing import Union, Any, Dict
 
 from rapyuta_io import Client
-from rapyuta_io.clients.native_network import NativeNetwork, \
-    NativeNetworkLimits, Parameters as NativeNetworkParameters
-from rapyuta_io.clients.routed_network import RoutedNetwork, \
-    RoutedNetworkLimits, Parameters as RoutedNetworkParameters
+from rapyuta_io.clients.native_network import NativeNetwork, Parameters as NativeNetworkParameters
+from rapyuta_io.clients.routed_network import RoutedNetwork, Parameters as RoutedNetworkParameters
 
 from riocli.model import Model
 from riocli.network.util import find_network_name, NetworkNotFound
@@ -26,19 +24,6 @@ from riocli.utils.validate import validate_manifest, load_schema
 
 
 class Network(Model):
-    _RoutedNetworkLimits = {
-        'small': RoutedNetworkLimits.SMALL,
-        'medium': RoutedNetworkLimits.MEDIUM,
-        'large': RoutedNetworkLimits.LARGE,
-    }
-
-    _NativeNetworkLimits = {
-        'xSmall': NativeNetworkLimits.X_SMALL,
-        'small': NativeNetworkLimits.SMALL,
-        'medium': NativeNetworkLimits.MEDIUM,
-        'large': NativeNetworkLimits.LARGE,
-
-    }
 
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)
@@ -76,6 +61,7 @@ class Network(Model):
     def pre_process(cls, client: Client, d: Dict) -> None:
         pass
 
+
     def to_v1(self, client: Client) -> NativeNetwork:
         if self.spec.runtime == 'cloud':
             limits = self._get_limits()
@@ -105,12 +91,6 @@ class Network(Model):
         return client.create_device_routed_network(name=self.metadata.name, ros_distro=self.spec.rosDistro, shared=True,
                                                    device=device,
                                                    network_interface=self.spec.networkInterface)
-
-    def _get_limits(self) -> Union[RoutedNetworkLimits, NativeNetworkLimits]:
-        if self.spec.type == 'routed':
-            return self._RoutedNetworkLimits[self.spec.resourceLimits]
-        else:
-            return self._NativeNetworkLimits[self.spec.resourceLimits]
 
     @staticmethod
     def validate(data):

--- a/riocli/network/native_network.py
+++ b/riocli/network/native_network.py
@@ -15,21 +15,24 @@ import typing
 
 import click
 from click_spinner import spinner
-from rapyuta_io.clients.native_network import NativeNetwork, Parameters, NativeNetworkLimits
+from rapyuta_io.clients.native_network import NativeNetwork, Parameters
 from rapyuta_io.clients.package import Runtime, ROSDistro
-
+from rapyuta_io.clients.common_models import Limits
 from riocli.config import new_client
 
 
 def create_native_network(name: str, ros: str, device_guid: str = None, network_interface: str = None,
-                          limit: str = None, restart_policy: str = None, **kwargs: typing.Any) -> None:
+                          cpu: float = 0, memory: int = 0, restart_policy: str = None, **kwargs: typing.Any) -> None:
     client = new_client()
 
     ros_distro = ROSDistro(ros)
     runtime = Runtime.CLOUD
 
-    if limit is not None:
-        limit = getattr(NativeNetworkLimits, limit.upper())
+    limit = None
+    if cpu or memory:
+        if device_guid:
+            raise Exception('Native network for device does not support cpu or memory')
+        limit = Limits(cpu, memory)
 
     device = None
     if device_guid:

--- a/riocli/network/routed_network.py
+++ b/riocli/network/routed_network.py
@@ -17,16 +17,22 @@ import click
 from click_spinner import spinner
 from rapyuta_io import ROSDistro
 from rapyuta_io.clients.package import RestartPolicy
-from rapyuta_io.clients.routed_network import RoutedNetworkLimits, Parameters
-
+from rapyuta_io.clients.routed_network import Parameters
+from rapyuta_io.clients.common_models import Limits
 from riocli.config import new_client
 
 
 def create_routed_network(name: str, ros: str, device_guid: str = None, network_interface: str = None,
-                          limit: str = None, restart_policy: str = None, **kwargs: typing.Any) -> None:
+                          cpu: float = 0, memory: int = 0, restart_policy: str = None, **kwargs: typing.Any) -> None:
     client = new_client()
     ros_distro = ROSDistro(ros)
-    limit = getattr(RoutedNetworkLimits, limit.upper())
+
+    limit = None
+    if cpu or memory:
+        if device_guid:
+            raise Exception('Routed network for device does not support cpu or memory')
+        limit = Limits(cpu, memory)
+
     if restart_policy:
         restart_policy = RestartPolicy(restart_policy)
 
@@ -38,8 +44,9 @@ def create_routed_network(name: str, ros: str, device_guid: str = None, network_
                                                 network_interface=network_interface,
                                                 restart_policy=restart_policy)
         else:
+            parameters = None if not limit else Parameters(limit)
             client.create_cloud_routed_network(name, ros_distro=ros_distro, shared=False,
-                                               parameters=Parameters(limit))
+                                               parameters=parameters)
 
     click.secho('Routed Network created successfully!', fg='green')
 


### PR DESCRIPTION
### Description
rapyuta.io backend already supports custom cpu and memory values for cloud networks. You can specify cpu in multiples of 0.025 cores and memory in multiples of 128MiB. Added a change in cli where cloud network can be created using custom CPU cores and memory.

Below is sample manifest that can be used.

```yaml
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Network"
metadata:
  name: "cloud-native-network5"
spec:
  runtime: "cloud"
  type: "routed"
  rosDistro: "melodic"
  resourceLimits:
    cpu:  0.5
    memory: 1024
```

following commands can also be used to create cloud native/routed network

```bash
rio network create --network=routed  --ros=melodic  testT124  --cpu=1  --memory=1024
```



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1087893985)
