### PR TITLE
chore: adds workflow to check commit hygiene

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,18 @@
+name: Check Commit Hygiene 💬
+
+on:
+  pull_request:
+    branches:
+      - main
+      - devel
+
+jobs:
+  verify:
+    name: Conventional Commits
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout code
+
+    - uses: webiny/action-conventional-commits@v1.1.0
+      name: Check if commit messages are compliant


### PR DESCRIPTION
The commit adds a workflow to check if the commit messages are compliant with conventional commits.

https://www.conventionalcommits.org/en/v1.0.0/#summary

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1089239256)
