### PR TITLE
fix(gh-actions): code quality workflow does not comment on pr

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,6 +18,5 @@ jobs:
         continue-on-error: true
         with:
           path: ./riocli
-          reporter: 'github-pr-review'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

This PR updates the code quality workflow to not comment on the PR.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1094345822)
