### PR TITLE
fix(parameter): handles the non-directory tree names

### DIFF
--- a/riocli/parameter/utils.py
+++ b/riocli/parameter/utils.py
@@ -37,6 +37,9 @@ def filter_trees(root_dir: str, tree_names: typing.Tuple[str]) -> typing.List[st
 
         trees.append(each)
 
+    if tree_names and not trees:
+        raise Exception('specified tree names are invalid')
+
     return trees
 
 


### PR DESCRIPTION
The `parameter` commands were accepting non-existing Tree-names. But instead of raising the error, it was instead acting as if no Tree-name was specified and uploading all trees in the Path.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1098520918)
