### PR TITLE
fix(jsonschema): sets default values defined in the schema

### DIFF
--- a/riocli/build/model.py
+++ b/riocli/build/model.py
@@ -15,8 +15,8 @@ import typing
 
 from rapyuta_io import Build as v1Build, Client, BuildOptions, CatkinOption
 
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
-from riocli.jsonschema.validate import validate_manifest, load_schema
 
 
 class Build(Model):
@@ -75,4 +75,4 @@ class Build(Model):
         Validates if build data is matching with its corresponding schema
         """
         schema = load_schema('build')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)

--- a/riocli/deployment/model.py
+++ b/riocli/deployment/model.py
@@ -29,10 +29,10 @@ from rapyuta_io.clients.routed_network import RoutedNetwork
 
 from riocli.deployment.errors import ERRORS
 from riocli.deployment.util import add_mount_volume_provision_config
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
 from riocli.package.util import find_package_guid
 from riocli.static_route.util import find_static_route_guid
-from riocli.jsonschema.validate import validate_manifest, load_schema
 
 
 class Deployment(Model):
@@ -324,7 +324,7 @@ class Deployment(Model):
         Validates if deployment data is matching with its corresponding schema
         """
         schema = load_schema('deployment')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)
 
 
 def process_deployment_errors(e: DeploymentNotRunningException):

--- a/riocli/device/model.py
+++ b/riocli/device/model.py
@@ -16,8 +16,8 @@ import typing
 from rapyuta_io import Client
 from rapyuta_io.clients.device import Device as v1Device, DevicePythonVersion
 
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
-from riocli.jsonschema.validate import validate_manifest, load_schema
 
 
 class Device(Model):
@@ -71,4 +71,4 @@ class Device(Model):
         Validates if device data is matching with its corresponding schema
         """
         schema = load_schema('device')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)

--- a/riocli/disk/model.py
+++ b/riocli/disk/model.py
@@ -21,8 +21,8 @@ from rapyuta_io import Client
 from rapyuta_io.utils.rest_client import HttpMethod
 
 from riocli.disk.util import _api_call
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
-from riocli.jsonschema.validate import load_schema, validate_manifest
 
 
 class Disk(Model):
@@ -80,4 +80,4 @@ class Disk(Model):
     @staticmethod
     def validate(data):
         schema = load_schema('disk')
-        validate_manifest(data, schema)
+        schema.validate(data)

--- a/riocli/managedservice/model.py
+++ b/riocli/managedservice/model.py
@@ -16,9 +16,9 @@ import typing
 from munch import munchify
 from rapyuta_io import Client
 
+from riocli.jsonschema.validate import load_schema
 from riocli.managedservice.util import ManagedServicesClient
 from riocli.model import Model
-from riocli.jsonschema.validate import load_schema, validate_manifest
 
 
 class ManagedService(Model):
@@ -59,4 +59,4 @@ class ManagedService(Model):
         Validates if managedservice data is matching with its corresponding schema
         """
         schema = load_schema('managedservice')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)

--- a/riocli/network/model.py
+++ b/riocli/network/model.py
@@ -15,13 +15,15 @@ import typing
 from typing import Union, Any, Dict
 
 from rapyuta_io import Client
-from rapyuta_io.clients.native_network import NativeNetwork, Parameters as NativeNetworkParameters
-from rapyuta_io.clients.routed_network import RoutedNetwork, Parameters as RoutedNetworkParameters
 from rapyuta_io.clients.common_models import Limits
+from rapyuta_io.clients.native_network import NativeNetwork, \
+    Parameters as NativeNetworkParameters
+from rapyuta_io.clients.routed_network import RoutedNetwork, \
+    Parameters as RoutedNetworkParameters
 
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
 from riocli.network.util import find_network_name, NetworkNotFound
-from riocli.jsonschema.validate import validate_manifest, load_schema
 
 
 class Network(Model):
@@ -102,4 +104,4 @@ class Network(Model):
         Validates if network data is matching with its corresponding schema
         """
         schema = load_schema('network')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)

--- a/riocli/package/model.py
+++ b/riocli/package/model.py
@@ -18,8 +18,8 @@ from munch import munchify
 from rapyuta_io import Client
 from rapyuta_io.clients.package import RestartPolicy
 
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
-from riocli.jsonschema.validate import validate_manifest, load_schema
 
 
 class Package(Model):
@@ -249,4 +249,4 @@ class Package(Model):
         Validates if package data is matching with its corresponding schema
         """
         schema = load_schema('package')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)

--- a/riocli/project/model.py
+++ b/riocli/project/model.py
@@ -15,8 +15,8 @@ import typing
 
 from rapyuta_io import Project as v1Project, Client
 
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
-from riocli.jsonschema.validate import validate_manifest, load_schema
 
 
 class Project(Model):
@@ -55,4 +55,4 @@ class Project(Model):
         Validates if project data is matching with its corresponding schema
         """
         schema = load_schema('project')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)

--- a/riocli/secret/model.py
+++ b/riocli/secret/model.py
@@ -17,8 +17,8 @@ from rapyuta_io import Secret as v1Secret, SecretConfigDocker, \
     SecretConfigSourceBasicAuth, \
     SecretConfigSourceSSHAuth, Client
 
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
-from riocli.jsonschema.validate import load_schema, validate_manifest
 
 
 class Secret(Model):
@@ -79,4 +79,4 @@ class Secret(Model):
         Validates if secret data is matching with its corresponding schema
         """
         schema = load_schema('secret')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)

--- a/riocli/static_route/model.py
+++ b/riocli/static_route/model.py
@@ -16,8 +16,8 @@ import typing
 from rapyuta_io import Client
 from rapyuta_io.clients.static_route import StaticRoute as v1StaticRoute
 
+from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
-from riocli.jsonschema.validate import validate_manifest, load_schema
 
 
 class StaticRoute(Model):
@@ -52,4 +52,4 @@ class StaticRoute(Model):
         Validates if static route data is matching with its corresponding schema
         """
         schema = load_schema('static_route')
-        validate_manifest(instance=data, schema=schema)
+        schema.validate(data)


### PR DESCRIPTION
### Description
When we moved to validate `jsonschemas` on the fly instead of using the pre-compiled validation code, we regressed the existing implementation by not realizing that the validation isn't setting defaults anymore. In order to solve the issue, we referred to the following link,

https://python-jsonschema.readthedocs.io/en/stable/faq/#why-doesn-t-my-schema-s-default-property-set-the-default-on-my-instance

Since we are using the draft07 of JSONSchema, we referred to the article and updated the code to define a default validator by extending the Draft7Validator class to set defaults.

We now use this default validator instead of the `jsonschema.validate` method.

#### Dependencies
This PR depends on fixes to manifests in PR #155 

### Testing
<details>
  <summary>Click to view the entire manifest</summary>

```yaml
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Secret"
metadata:
  name: "sootballs"
  guid: secret-vebkjobybhhwmyiwkwvndagu
spec:
  type: Docker
  docker:
    username: shaishavrapyuta
    password: asdfg123$
    email: shaishavrapyuta
    # registry: https://index.docker.io/v1/
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: "Sootballs SUI2"
  version: "1.0.0"
  labels:
    app: sootballs
spec:
  runtime: "cloud"
  ros:
    enabled: True
    version: "melodic"
    rosEndpoints:
      - name: "/cmd_global_charge"
        type: "topic"
        qos: "hi"
      - name: "/cmd_global_in"
        type: "topic"
        qos: "hi"
      - name: "/cmd_move_to"
        type: "topic"
        qos: "hi"
      - name: "/dispatcher/active_tote_unload_request"
        type: "topic"
        qos: "low"
      - name: "/dispatcher/control_request"
        type: "topic"
        qos: "low"
      - name: "/dispatcher/modify_order_request"
        type: "topic"
        qos: "low"
      - name: "/dispatcher/productivity_configs_request"
        type: "topic"
        qos: "low"
      - name: "/edge/emergency_released_request"
        type: "topic"
        qos: "low"
      - name: "/manual_order_recovery"
        type: "topic"
        qos: "hi"
      - name: "/reservation_request"
        type: "topic"
        qos: "hi"
  cloud:
    replicas: 1
  executables:
    - name: "systemui"
      type: docker
      docker:
        image: "rrdockerhub/sootballs:{{ testlabel }}"
        pullSecret:
          depends:
            kind: secret
            nameOrGUID: sootballs
      command: "roslaunch sootballs_applications_edge remote_ui.launch"
      runAsBash: False
      limits:
        cpu: 2
        memory: 8192

  environmentVars:
    - name: "IMS_AUTH_USERNAME"
      description: "Username to authenticate to IMS"
      defaultValue: "root"
    - name: "IMS_AUTH_PASSWORD"
      description: "Password to authenticate to IMS"
      defaultValue: "airborne_rr"
    - name: "SENTRY_DSN"
      description: "Password to authenticate to IMS"
      defaultValue: "https://a83904fb2f394a768557eaea8ec39db4:7d8a02b629994bf884534917dfb08511@sentry.svc.rapyuta.io/18"
    - name: "SOOTBALLS_MAP"
      defaultValue: "rrkibstg"
    - name: "SYSTEM_UI_REMOTE_MODE"
      defaultValue: "true"
    - name: "WS_EXTERNAL_PORT"
      defaultValue: "80"
    - name: "DOCKER_STDOUT"
      defaultValue: "true"
  endpoints:
    - name: "SYSTEM_UI"
      type: external-https
      port: 443
      targetPort: 7099
    - name: "SYSTEM_UI_ROSBRIDGE_URL"
      type: external-https
      port: 443
      targetPort: 9092
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: "Sootballs Edge2"
  version: "1.0.0"
  labels:
    app: sootballs
spec:
  runtime: "device"
  device:
    arch: amd64
    restart: always
  ros:
    enabled: True
    version: "melodic"
    rosEndpoints:
      - name: "/dispatcher/control_response"
        type: "topic"
        qos: "low"
      - name: "/dispatcher/modify_order_response"
        type: "topic"
        qos: "low"
      - name: "/dispatcher/productivity_configs_response"
        type: "topic"
        qos: "low"
      - name: "/dispatcher/active_tote_unload_response"
        type: "topic"
        qos: "low"
      - name: "/edge/emergency_released_response"
        type: "topic"
        qos: "low"
      - name: "/robot_reservation"
        type: "topic"
        qos: "low"
      - name: "/sui/status"
        type: "topic"
        qos: "low"
      - name: "/sui/overview"
        type: "topic"
        qos: "low"
      - name: "/sui/main"
        type: "topic"
        qos: "low"
  executables:
    - name: "systemui"
      type: docker
      docker:
        image: "rrdockerhub/sootballs:{{ testlabel }}"
        pullSecret:
          depends:
            kind: secret
            nameOrGUID: sootballs
      command: "roslaunch sootballs_applications_edge default.launch --wait"
      runAsBash: False

  environmentVars:
    - name: "IMS_AUTH_USERNAME"
      description: "Username to authenticate to IMS"
      defaultValue: "root"
    - name: "IMS_AUTH_PASSWORD"
      description: "Password to authenticate to IMS"
      defaultValue: "airborne_rr"
    - name: "SENTRY_DSN"
      description: "Password to authenticate to IMS"
      defaultValue: "https://a83904fb2f394a768557eaea8ec39db4:7d8a02b629994bf884534917dfb08511@sentry.svc.rapyuta.io/18"
    - name: "DOCKER_STDOUT"
      defaultValue: "true"
    - name: "DISABLE_MULTICAST"
      defaultValue: "false"
    - name: "ROS_DOMAIN_ID"
      defaultValue: "10"
    - name: "USE_PARAMS_IO"
      defaultValue: "true"
    - name: "EDGE_ALARM_MONITOR"
      defaultValue: "true"
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: "Sootballs Robot2"
  version: "1.0.0"
  labels:
    app: sootballs
spec:
  runtime: "device"
  device:
    arch: amd64
    restart: always
  ros:
    enabled: True
    version: "melodic"
  executables:
    - name: "systemui"
      type: docker
      docker:
        image: "rrdockerhub/sootballs:{{ testlabel }}"
        pullSecret:
          depends:
            kind: secret
            nameOrGUID: sootballs
      command: "roslaunch sootballs_applications_robot default.launch --wait"
      runAsBash: False

  environmentVars:
    - name: "IMS_AUTH_USERNAME"
      description: "Username to authenticate to IMS"
      defaultValue: "root"
    - name: "IMS_AUTH_PASSWORD"
      description: "Password to authenticate to IMS"
      defaultValue: "airborne_rr"
    - name: "SENTRY_DSN"
      description: "Password to authenticate to IMS"
      defaultValue: "https://a83904fb2f394a768557eaea8ec39db4:7d8a02b629994bf884534917dfb08511@sentry.svc.rapyuta.io/18"
    - name: "DOCKER_STDOUT"
      defaultValue: "true"
    - name: "DISABLE_MULTICAST"
      defaultValue: "false"
    - name: "ROS_DOMAIN_ID"
      defaultValue: "10"
    - name: "USE_PARAMS_IO"
      defaultValue: "true"
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: sootballs_ims
  version: v1.14.0-rc4-6
  description: Sootballs IMS Package
  labels:
    app: ims
spec:
  runtime: cloud
  cloud:
    replicas: 1
  executables:
    - type: docker
      name: Django
      docker:
        image: rrdockerhub/sootballs_ims:{{ testlabel }}
        pullSecret:
          depends:
            kind: secret
            nameOrGUID: sootballs
      limits:
        cpu: 0.5
        memory: 2048
      command: "/code/docker/entrypoint.sh"
  environmentVars:
    - name: SECRET_KEY
    - name: AUTH_ENABLED
      default: "False"
    - name: TIMEZONE
      default: "Asia/Tokyo"
    - name: CONTAINER_NAME
      default: "warehouse"
    - name: DAYS_BEFORE_ARCHIVE
      default: "15"
    - name: DEPLOY_ON_CLOUD
      default: "False"
    - name: SODTIME
      default: "09:00"
    - name: EODTIME
      default: "19:00"
    - name: AWS_STORAGE_BUCKET_NAME
      default: "kiba-robots"
    - name: IMS_DB
      default: ims_db
    - name: CELERY_BROKER_URL
    - name: CELERY_RESULT_BACKEND

  endpoints:
    - name: IMS_URL
      type: external-https
      port: 443
      targetPort: 8002
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: sootballs_db
  version: v1.0.11
  description: Sootballs DB package
  labels:
    app: ims
spec:
  runtime: cloud
  cloud:
    replicas: 1
  executables:
    - type: docker
      name: redis
      docker:
        image: redis:4.0-alpine
      limits:
        cpu: 0.5
        memory: 2048
    - type: docker
      name: postgres
      docker:
        image: postgis/postgis:9.6-3.2
      limits:
        cpu: 1
        memory: 4096
  environmentVars:
    - name: POSTGRES_MULTIPLE_DATABASES
      default: ims_db,wcs_db
    - name: PGDATA
      default: /var/lib/postgresql/data/pgdata
    - name: POSTGRES_HOST_AUTH_METHOD
      default: trust
    - name: POSTGRES_USER
      default: postgres
      exposed: true
      exposedName: POSTGRES_USER
    - name: POSTGRES_PASSWORD
      default: password
      exposed: true
      exposedName: POSTGRES_PASSWORD
  endpoints:
    - name: POSTGRES
      type: internal-tcp
      port: 5432
      targetPort: 5432
    - name: REDIS
      type: internal-tcp
      port: 6379
      targetPort: 6379
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: MinIO File Server
  version: v1.0.11
  description: Sootballs File Server package
  labels:
    app: ims
spec:
  runtime: cloud
  cloud:
    replicas: 1
  executables:
    - type: docker
      name: minio_executable
      docker:
        image: rrdockerhub/minio-server
      limits:
        cpu: 1
        memory: 4096
  environmentVars:
    - name: MINIO_ACCESS_KEY
    - name: MINIO_SECRET_KEY
  endpoints:
    - name: MINIO
      type: external-https
      port: 443
      targetPort: 9000
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: sootballs_wcs
  version: v1.14.0-rc4-2
  description: Sootballs WCS package
  labels:
    app: wcs
spec:
  runtime: cloud
  cloud:
    replicas: 1
  executables:
    - type: docker
      name: django
      command: /code/docker/entrypoint.sh
      docker:
        image: rrdockerhub/sootballs_wcs:{{ testlabel}}
        pullSecret:
          depends:
            kind: secret
            nameOrGUID: sootballs
      limits:
        cpu: 1
        memory: 4096
  environmentVars:
    - name: TIMEZONE
      default: Asia/Tokyo
    - name: WCS_DB
      default: wcs_db
    - name: CELERY_BROKER_URL
    - name: CELERY_RESULT_BACKEND
    - name: LOCAL_PRINT_SERVER_URL
    - name: SECRET_KEY
  endpoints:
    - name: WCS_URL
      type: external-https
      port: 443
      targetPort: 8003
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Disk"
metadata:
  name: "postgres-pvc"
spec:
  runtime: cloud
  capacity: 4
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Disk"
metadata:
  name: "minio-pvc"
spec:
  runtime: cloud
  capacity: 4
---
#sootballs_staticroutes
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "StaticRoute"
metadata:
  name: "ims-{{ routePrefix }}"
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "StaticRoute"
metadata:
  name: "minio-{{ routePrefix }}"
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "StaticRoute"
metadata:
  name: "wcs-{{ routePrefix }}"
---
#sootballs_minio
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: sootballs_minio
  depends:
    kind: package
    nameOrGUID: "MinIO File Server"
    version: "v1.0.11"
  labels:
    app: ims
spec:
  runtime: cloud
  envArgs:
    - name: MINIO_ACCESS_KEY
      value: access
    - name: MINIO_SECRET_KEY
      value: secret_key
  staticRoutes:
    - name: MINIO
      depends:
        kind: staticroute
        nameOrGUID: minio-{{ routePrefix }}
  volumes:
    - execName: minio_executable
      mountPath: "/data"
      subPath: "data"
      depends:
        kind: disk
        nameOrGUID: "minio-pvc"
---
#sootballs_db
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: sootballs_db
  depends:
    kind: package
    nameOrGUID: sootballs_db
    version: "v1.0.11"
  labels:
    app: ims
spec:
  runtime: cloud
  envArgs:
    - name: PGDATA
      value: /var/lib/postgresql/data/pgdata
    - name: POSTGRES_HOST_AUTH_METHOD
      value: trust
    - name: POSTGRES_MULTIPLE_DATABASES
      value: ims_db,wcs_db
    - name: POSTGRES_PASSWORD
      value: sootballs
    - name: POSTGRES_USER
      value: postgres
  volumes:
    - execName: postgres
      mountPath: "/var/lib/postgresql/data/pgdata"
      subPath: "pgdata"
      depends:
        kind: disk
        nameOrGUID: "postgres-pvc"

#sootballs_ims
---
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: sootballs_ims
  depends:
    kind: package
    nameOrGUID: "sootballs_ims"
    version: "v1.14.0-rc4-6"
  labels:
    app: ims
spec:
  runtime: cloud
  depends:
    - kind: deployment
      nameOrGUID: sootballs_db
    - kind: deployment
      nameOrGUID: sootballs_minio
  envArgs:
    - name: AUTH_ENABLED
      value: "True"
    - name: AWS_STORAGE_BUCKET_NAME
      value: kiba-robots
    #TODO  this should be parsed from redis url in the docker container.
    - name: CELERY_BROKER_URL
      value: rediss://inst-lrxokslpvkctnstujixsczsw-redis-srv.dep-ns-inst-lrxokslpvkctnstujixsczsw.svc:6379/5
    #TODO  this should be parsed from redis url in the docker container.
    - name: CELERY_RESULT_BACKEND
      value: rediss://inst-lrxokslpvkctnstujixsczsw-redis-srv.dep-ns-inst-lrxokslpvkctnstujixsczsw.svc:6379/5
    - name: CONTAINER_NAME
      value: warehouse
    - name: DAYS_BEFORE_ARCHIVE
      value: "15"
    - name: DEPLOY_ON_CLOUD
      value: "False"
    - name: EODTIME
      value: "19:00"
    - name: IMS_DB
      value: ims_db
    - name: SECRET_KEY
      value: asdasd
    - name: SODTIME
      value: 09:00
    - name: TIMEZONE
      value: Asia/Tokyo
    - name: TEST_ENV
      value: asdsad
  staticRoutes:
    - name: IMS_URL
      depends:
        kind: staticroute
        nameOrGUID: ims-{{ routePrefix }}
---
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: sootballs_wcs
  depends:
    kind: package
    nameOrGUID: sootballs_wcs
    version: "v1.14.0-rc4-2"
  labels:
    app: wcs
spec:
  runtime: cloud
  depends:
    - kind: deployment
      nameOrGUID: sootballs_db
    - kind: deployment
      nameOrGUID: sootballs_ims
  envArgs:
    - name: CELERY_BROKER_URL
      value: rediss://inst-lrxokslpvkctnstujixsczsw-redis-srv.dep-ns-inst-lrxokslpvkctnstujixsczsw.svc:6379/5
    - name: CELERY_RESULT_BACKEND
      value: rediss://inst-lrxokslpvkctnstujixsczsw-redis-srv.dep-ns-inst-lrxokslpvkctnstujixsczsw.svc:6379/5
    - name: LOCAL_PRINT_SERVER_URL
      value: " "
    - name: SECRET_KEY
      value: asdasd
    - name: TIMEZONE
      value: Asia/Tokyo
    - name: WCS_DB
      value: wcs_db
---
#sootballs_staticroutes
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "StaticRoute"
metadata:
  name: "ui-{{ routePrefix }}"
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Network"
metadata:
  name: "sootballs"
spec:
  runtime: "cloud"
  type: "routed"
  rosDistro: "melodic"
  resourceLimits:
    cpu: 1.000
    memory: 1024
---
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: sootballs_systemui
  depends:
    kind: package
    nameOrGUID: Sootballs SUI2
    version: "1.0.0"
  labels:
    app: systemui
spec:
  runtime: cloud
  depends:
    - kind: deployment
      nameOrGUID: sootballs_ims
  rosNetworks:
    - depends:
        kind: network
        nameOrGUID: sootballs
  envArgs:
    - name: DOCKER_STDOUT
      value: "true"
    - name: IMS_AUTH_PASSWORD
      value: airborne_rr
    - name: IMS_AUTH_USERNAME
      value: root
    - name: SENTRY_DSN
      value: https://a83904fb2f394a768557eaea8ec39db4:7d8a02b629994bf884534917dfb08511@sentry.svc.rapyuta.io/18
    - name: SOOTBALLS_MAP
      value: rrkibstg
    - name: SYSTEM_UI_REMOTE_MODE
      value: "true"
    - name: USE_LOCAL_MAP
      value: "false"
    - name: WS_EXTERNAL_PORT
      value: "80"
  staticRoutes:
    - name: SYSTEM_UI
      depends:
        kind: staticroute
        nameOrGUID: ui-{{ routePrefix }}

---
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: sootballs_edge_01
  depends:
    kind: package
    nameOrGUID: "Sootballs Edge2"
    version: "1.0.0"
spec:
  runtime: device
  depends:
    - kind: deployment
      nameOrGUID: sootballs_ims
  rosNetworks:
    - depends:
        kind: network
        nameOrGUID: sootballs
  envArgs:
    - name: IMS_AUTH_USERNAME
      value: root
    - name: IMS_AUTH_PASSWORD
      value: airborne_rr
    - name: "SENTRY_DSN"
      value: "https://a83904fb2f394a768557eaea8ec39db4:7d8a02b629994bf884534917dfb08511@sentry.svc.rapyuta.io/18"
    - name: "DOCKER_STDOUT"
      value: "true"
    - name: "DISABLE_MULTICAST"
      value: "false"
    - name: "ROS_DOMAIN_ID"
      value: "10"
    - name: "USE_PARAMS_IO"
      value: "true"
    - name: "EDGE_ALARM_MONITOR"
      value: "true"
---
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: sootballs_amr_01
  depends:
    kind: package
    nameOrGUID: "Sootballs Robot2"
    version: "1.0.0"
spec:
  runtime: device
  depends:
    - kind: deployment
      nameOrGUID: sootballs_ims
  rosNetworks:
    - depends:
        kind: network
        nameOrGUID: sootballs
  envArgs:
    - name: IMS_AUTH_USERNAME
      value: root
    - name: IMS_AUTH_PASSWORD
      value: airborne_rr
    - name: "SENTRY_DSN"
      value: "https://a83904fb2f394a768557eaea8ec39db4:7d8a02b629994bf884534917dfb08511@sentry.svc.rapyuta.io/18"
    - name: "DOCKER_STDOUT"
      value: "true"
    - name: "DISABLE_MULTICAST"
      value: "false"
    - name: "ROS_DOMAIN_ID"
      value: "10"
    - name: "USE_PARAMS_IO"
      value: "true"
```

</details>

values.yaml

```yaml
testlabel: 1.14.0-rc4
routePrefix: rc4
```

#### Result


```bash
→ pipenv run python -m riocli apply ~/workspace/test-rio-manifests/all-in-one/manifest.yaml --values ~/workspace/test-rio-manifests/all-in-one/values.yaml --dryrun
----- Files Processed ----
/home/pallab/workspace/test-rio-manifests/all-in-one/manifest.yaml
                       Resource Context
--------------------  ------------------
Expected Time (mins)         36.6
Files                         1
Resources                     22

Resource                       Action     Expected Time (mins)
-----------------------------  --------  ----------------------
secret:sootballs               CREATE             0.05
package:sootballs_db           CREATE             0.05
package:MinIO File Server      CREATE             0.05
disk:postgres-pvc              CREATE              3
disk:minio-pvc                 CREATE              3
staticroute:ims-rc4            CREATE             0.05
staticroute:minio-rc4          CREATE             0.05
staticroute:wcs-rc4            CREATE             0.05
staticroute:ui-rc4             CREATE             0.05
network:sootballs              CREATE              2
package:Sootballs SUI2         CREATE             0.05
package:Sootballs Edge2        CREATE             0.05
package:Sootballs Robot2       CREATE             0.05
package:sootballs_ims          CREATE             0.05
package:sootballs_wcs          CREATE             0.05
deployment:sootballs_db        CREATE              4
deployment:sootballs_minio     CREATE              4
deployment:sootballs_ims       CREATE              4
deployment:sootballs_wcs       CREATE              4
deployment:sootballs_systemui  CREATE              4
deployment:sootballs_edge_01   CREATE              4
deployment:sootballs_amr_01    CREATE              4

>> ⌛ Create staticroute:ims-rc4                                                                                                             [2023-05-05T16:30:12.572091]
>> ⌛ Create package:MinIO File Server                                                                                                       [2023-05-05T16:30:12.595820]
>> ⌛ Create secret:sootballs                                                                                                                [2023-05-05T16:30:12.604727]
>> ⌛ Create disk:postgres-pvc                                                                                                               [2023-05-05T16:30:12.705812]
>> ⌛ Create package:sootballs_db                                                                                                            [2023-05-05T16:30:12.719925]
>> ⌛ Create disk:minio-pvc                                                                                                                  [2023-05-05T16:30:12.737642]
>> ⌛ Create staticroute:minio-rc4                                                                                                           [2023-05-05T16:30:13.340181]
>> ⌛ Create staticroute:ui-rc4                                                                                                              [2023-05-05T16:30:13.519539]
>> ⌛ Create staticroute:wcs-rc4                                                                                                             [2023-05-05T16:30:13.671765]
>> ⌛ Create network:sootballs                                                                                                               [2023-05-05T16:30:13.720552]
>> ⌛ Create package:Sootballs Edge2                                                                                                         [2023-05-05T16:30:13.865567]
>> ⌛ Create package:Sootballs SUI2                                                                                                          [2023-05-05T16:30:13.906637]
>> ⌛ Create package:Sootballs Robot2                                                                                                        [2023-05-05T16:30:13.984050]
>> ⌛ Create package:sootballs_ims                                                                                                           [2023-05-05T16:30:14.175435]
>> ⌛ Create deployment:sootballs_db                                                                                                         [2023-05-05T16:30:14.321674]
>> ⌛ Create package:sootballs_wcs                                                                                                           [2023-05-05T16:30:14.410117]
>> ⌛ Create deployment:sootballs_minio                                                                                                      [2023-05-05T16:30:14.414807]
>> ⌛ Create deployment:sootballs_ims                                                                                                        [2023-05-05T16:30:14.924459]
>> ⌛ Create deployment:sootballs_systemui                                                                                                   [2023-05-05T16:30:15.793887]
>> ⌛ Create deployment:sootballs_amr_01                                                                                                     [2023-05-05T16:30:15.813485]
>> ⌛ Create deployment:sootballs_edge_01                                                                                                    [2023-05-05T16:30:15.815287]
>> ⌛ Create deployment:sootballs_wcs                                                                                                        [2023-05-05T16:30:15.819073]
```



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1100229074)
