### PR TITLE
fix(device): fixes delete command

### DIFF
--- a/riocli/device/delete.py
+++ b/riocli/device/delete.py
@@ -30,7 +30,7 @@ def delete_device(device_name: str, device_guid: str, force: bool):
         click.confirm('Deleting device {} ({})'.format(device_name, device_guid), abort=True)
 
     try:
-        client = new_client(with_project=False)
+        client = new_client(with_project=True)
         with click_spinner.spinner():
             client.delete_device(device_id=device_guid)
         click.secho('Device deleted successfully!', fg='green')


### PR DESCRIPTION
The Client used for the `delete` command was without project. This was leading to Project Header not being set in the HTTP Request resulting in Bad Request. The CLI was masking that and showing success message regardless. This commit fixes the issue.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1109806269)
