### PR TITLE
feat: adds fractional resource limits for device

### DIFF
--- a/riocli/apply/manifests/package-nonros-device.yaml
+++ b/riocli/apply/manifests/package-nonros-device.yaml
@@ -17,9 +17,9 @@ spec:
       type: build # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       build:
         depends:
           kind: build
@@ -28,9 +28,9 @@ spec:
       type: docker # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       docker:
         image: "busybox:latest"
         pullSecret:

--- a/riocli/apply/manifests/package-ros-device-no-rosbag.yaml
+++ b/riocli/apply/manifests/package-ros-device-no-rosbag.yaml
@@ -18,9 +18,9 @@ spec:
       type: build # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       build:
         depends:
           kind: build
@@ -29,9 +29,9 @@ spec:
       type: docker # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       docker:
         image: "busybox:latest"
         pullSecret:

--- a/riocli/apply/manifests/package-ros-device-rosbag.yaml
+++ b/riocli/apply/manifests/package-ros-device-rosbag.yaml
@@ -18,9 +18,9 @@ spec:
       type: build # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       build:
         depends:
           kind: build
@@ -29,9 +29,9 @@ spec:
       type: docker # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       docker:
         image: "busybox:latest"
         pullSecret:

--- a/riocli/apply/manifests/package.yaml
+++ b/riocli/apply/manifests/package.yaml
@@ -163,9 +163,9 @@ spec:
       type: build # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       build:
         depends:
           kind: build
@@ -174,9 +174,9 @@ spec:
       type: docker # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       docker:
         image: "busybox:latest"
         pullSecret:
@@ -373,9 +373,9 @@ spec:
       type: build # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       build:
         depends:
           kind: build
@@ -384,9 +384,9 @@ spec:
       type: docker # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
-      limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       docker:
         image: "busybox:latest"
         pullSecret:
@@ -427,8 +427,8 @@ spec:
       command: "roslaunch talker talker.launch"
       runAsBash: True
       limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       build:
         depends:
           kind: build
@@ -438,8 +438,8 @@ spec:
       command: "roslaunch talker talker.launch"
       runAsBash: True
       limits:
-        cpu: 0.025 # Unit: Core Options: [Multiple of 0.025, <= 8]
-        memory: 128 # Unit: MB Options: [Multiple of 128, <= 32768]
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
       docker:
         image: "busybox:latest"
         pullSecret:
@@ -481,4 +481,5 @@ spec:
         name: "/telemetry"
         compression: False
         scoped: False
+        targeted: False
         targeted: False

--- a/riocli/jsonschema/schemas/package-schema.yaml
+++ b/riocli/jsonschema/schemas/package-schema.yaml
@@ -127,6 +127,15 @@ definitions:
       runAsBash:
         type: boolean
         default: True
+      limits:
+        type: object
+        properties:
+          cpu:
+            type: number
+            minimum: 0
+          memory:
+            type: number
+            minimum: 0
     required:
       - type
     dependencies:
@@ -185,11 +194,13 @@ definitions:
         properties:
           cpu:
             type: number
+            default: 0.025
             min: 0.025
             max: 8.000
             multipleOf: 0.025
           memory:
             type: number
+            default: 128
             min: 128
             max: 32768
             multipleOf: 128

--- a/riocli/package/model.py
+++ b/riocli/package/model.py
@@ -194,8 +194,8 @@ class Package(Model):
 
         if 'limits' in exec:
             exec_object.limits = {
-                "cpu": exec.limits.cpu,
-                "memory": exec.limits.memory
+                'cpu': exec.limits.get('cpu', 0.0),
+                'memory': exec.limits.get('memory', 0)
             }
 
         if exec.get('runAsBash'):


### PR DESCRIPTION
Add support for CPU/Memory Limits on Device Components.

How to test?

https://drive.google.com/file/d/1cVgFyPEv3vlZS-WMX7NxbXPqLV7mO3sj/view?usp=sharing

Make sure https://github.com/rapyuta-robotics/deviceedge/pull/138 and  https://github.com/rapyuta-robotics/rapyuta_io/pull/364 rapyuta io branch is also deployed.

Deploy this package on device.
check docker inspect of the nginx pod.
You can also check docker stats.
run top command to see CPU usage by each process.

stress package shown in video

Tested scenarios:

Without providing any limits
Limits with only CPU
Limits with only Memory
Limits with both CPU and Memory

Test Package file https://drive.google.com/file/d/1NxMbyUgrv6KBDKx8XdLwZOkbF8vf_3UY/view?usp=sharing
Test Deployment file: https://drive.google.com/file/d/1dJmNmwRBxpa6-dP2pvi1a9A3Xz1zr5l8/view?usp=sharing
Test result: 

【 code  】
Pakage:  nginx-cloud-without-limits
        limits:
          cpu: 25m
          memory: 128Mi
        requests:
          cpu: 25m
          memory: 128Mi
【 end code 】

Pakage:  nginx-cloud-without-cpu
           limits:
          cpu: 25m
          memory: 512Mi
        requests:
          cpu: 25m
          memory: 512Mi

【 code  】
``
Package: nginx-cloud-without-memory

【 code  】
- resources:
    limits:
      cpu: '1'
      memory: 128Mi
    requests:
      cpu: '1'
      memory: 128Mi
【 end code 】

``
【 code  】
``
nginx-cloud-with-limits
    - resources:
        limits:
          cpu: '1'
          memory: 512Mi
        requests:
          cpu: '1'
          memory: 512Mi
``

Device results:
Package  device-nginx-without-cpu
docker inspect 2cf57c50ad87 | grep -i cpu
            "CpuShares": 2,
            "NanoCpus": 0,
            "CpuPeriod": 100000,
            "CpuQuota": 0,
            "CpuRealtimePeriod": 0,
            "CpuRealtimeRuntime": 0,
            "CpusetCpus": "",
            "CpusetMems": "",
            "CpuCount": 0,
            "CpuPercent": 0,

rapyuta@romil-device-test3:~ docker inspect 2cf57c50ad87 | grep -i memory
            "Memory": 536870912,
            "KernelMemory": 0,
            "KernelMemoryTCP": 0,
            "MemoryReservation": 0,
            "MemorySwap": -1,
            "MemorySwappiness": null,

Package: device-nginx-with-limits
rapyuta@romil-device-test3:~ docker inspect 1a7ba7e36155  | grep -i cpu
            "CpuShares": 30,
            "NanoCpus": 0,
            "CpuPeriod": 100000,
            "CpuQuota": 3000,
            "CpuRealtimePeriod": 0,
            "CpuRealtimeRuntime": 0,
            "CpusetCpus": "",
            "CpusetMems": "",
            "CpuCount": 0,
            "CpuPercent": 0,
rapyuta@romil-device-test3:~ docker inspect 1a7ba7e36155  | grep -i memory
            "Memory": 536870912,
            "KernelMemory": 0,
            "KernelMemoryTCP": 0,
            "MemoryReservation": 0,
            "MemorySwap": -1,
            "MemorySwappiness": null,

Package: device-nginx-without-limits
rapyuta@romil-device-test3:~ docker inspect ea3f3acaf095  | grep -i cpu
            "CpuShares": 2,
            "NanoCpus": 0,
            "CpuPeriod": 100000,
            "CpuQuota": 0,
            "CpuRealtimePeriod": 0,
            "CpuRealtimeRuntime": 0,
            "CpusetCpus": "",
            "CpusetMems": "",
            "CpuCount": 0,
            "CpuPercent": 0,
rapyuta@romil-device-test3:~ docker inspect ea3f3acaf095  | grep -i memory
            "Memory": 0,
            "KernelMemory": 0,
            "KernelMemoryTCP": 0,
            "MemoryReservation": 0,
            "MemorySwap": 0,
            "MemorySwappiness": null,

Package:  device-nginx-without-memory
rapyuta@romil-device-test3:~ docker inspect 5a04fbb5b9d9  | grep -i cpu
            "CpuShares": 30,
            "NanoCpus": 0,
            "CpuPeriod": 100000,
            "CpuQuota": 3000,
            "CpuRealtimePeriod": 0,
            "CpuRealtimeRuntime": 0,
            "CpusetCpus": "",
            "CpusetMems": "",
            "CpuCount": 0,
            "CpuPercent": 0,
rapyuta@romil-device-test3:~ docker inspect 5a04fbb5b9d9  | grep -i memory
            "Memory": 0,
            "KernelMemory": 0,
            "KernelMemoryTCP": 0,
            "MemoryReservation": 0,
            "MemorySwap": 0,
            "MemorySwappiness": null,

Package  to test if limits are being applied or not
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package" #We will create a package
metadata:
  name: "limits"
  version: "1.0.0"
  labels:
    app: test
spec:
  runtime: "device"
  device:
    arch: "amd64"
    restart: "always"
  ros:
    enabled: True
    version: "melodic"
  executables:
    - name: "exec"
      type: docker
      runAsBash: False
      docker:
        image: progrium/stress
      command: " --cpu 2 --io 1 --vm 2 --vm-bytes 512M --timeout 300s"
      limits:
        cpu: 1
        memory: 1024
【 end code 】



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1110688481)
