### PR TITLE
feat(apply): adds option show dependency graph (`mermaid-live`)

### DIFF
--- a/riocli/apply/parse.py
+++ b/riocli/apply/parse.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import copy
 import json
-import os
 import queue
 import threading
 import typing
@@ -138,14 +137,20 @@ class Applier(object):
         delete_order = list(self.graph.static_order())
         delete_order.reverse()
         for obj in delete_order:
-            if obj in self.resolved_objects and 'manifest' in self.resolved_objects[obj]:
+            if obj in self.resolved_objects and 'manifest' in \
+                    self.resolved_objects[obj]:
                 self._delete_manifest(obj, *args, **kwargs)
 
     def print_resolved_manifests(self):
         manifests = [o for _, o in self.objects.items()]
         dump_all_yaml(manifests)
 
-    def parse_dependencies(self, check_missing=True, delete=False, template=False):
+    def parse_dependencies(
+            self,
+            check_missing=True,
+            delete=False,
+            template=False,
+    ):
         number_of_objects = 0
         for f, data in self.files.items():
             for model in data:
@@ -170,7 +175,10 @@ class Applier(object):
 
         if not template:
             self._display_context(
-                total_time=total_time, total_objects=number_of_objects, resource_list=resource_list)
+                total_time=total_time,
+                total_objects=number_of_objects,
+                resource_list=resource_list,
+            )
 
         if check_missing:
             missing_resources = []
@@ -365,14 +373,19 @@ class Applier(object):
         if not self.dependencies.get(kind):
             self.dependencies[kind] = {}
 
+    def show_dependency_graph(self):
+        """Lauches mermaid.live dependency graph"""
+        link = mermaid_link("\n".join(self.diagram))
+        click.launch(link)
+
     # Utils
-    def _display_context(self, total_time: int, total_objects: int, resource_list: typing.List) -> None:
+    def _display_context(
+            self,
+            total_time: int,
+            total_objects: int,
+            resource_list: typing.List
+    ) -> None:
         # Display context
-
-        if os.environ.get('MERMAID'):
-            diagram_link = mermaid_link("\n".join(self.diagram))
-            click.launch(diagram_link)
-
         headers = [click.style('Resource Context', bold=True, fg='yellow')]
         context = [
             ['Expected Time (mins)', round(total_time, 2)],

--- a/riocli/utils/mermaid.py
+++ b/riocli/utils/mermaid.py
@@ -1,3 +1,17 @@
+# Copyright 2023 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import base64
 import json
 
@@ -6,39 +20,16 @@ def mermaid_safe(s: str):
     return s.replace(" ", "_")
 
 
-def js_string_to_byte(data):
+def js_string_to_byte(data: str):
     return bytes(data, 'iso-8859-1')
 
 
-def js_bytes_to_string(data):
+def js_bytes_to_string(data: bytes):
     return data.decode('iso-8859-1')
 
 
-def js_btoa(data):
+def js_btoa(data: bytes):
     return base64.b64encode(data)
-
-
-# def js_encode_uri_component(data):
-#     return quote(data)
-
-
-# def js_atob(data):
-#     return base64.b64decode(data)
-
-# def pako_inflate_raw(data):
-#     decompress = zlib.decompressobj(-15)
-#     decompressed_data = decompress.decompress(data)
-#     decompressed_data += decompress.flush()
-#     return decompressed_data
-
-
-# def pako_deflate_raw(data):
-#     compress = zlib.compressobj(
-#         zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15, 8,
-#         zlib.Z_DEFAULT_STRATEGY)
-#     compressed_data = compress.compress(js_string_to_byte(js_encode_uri_component(data)))
-#     compressed_data += compress.flush()
-#     return compressed_data
 
 
 def mermaid_link(diagram):
@@ -54,4 +45,5 @@ def mermaid_link(diagram):
     json_str = json.dumps(obj)
     json_bytes = js_string_to_byte(json_str)
     encoded_uri = js_btoa(json_bytes)
-    return "https://mermaid.live/view#base64:{}".format(js_bytes_to_string(encoded_uri))
+    return 'https://mermaid.live/view#base64:{}'.format(
+        js_bytes_to_string(encoded_uri))


### PR DESCRIPTION
This commit exposes the hidden feature of rio apply where you can visualise the dependency between various rapyuta.io resources in your manifests. It uses `mermaid.live` to show the visualization.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1111093208)
