### PR TITLE
feature(deployment): adds feature to execute commands on deployments

### DIFF
--- a/riocli/deployment/__init__.py
+++ b/riocli/deployment/__init__.py
@@ -21,6 +21,7 @@ from riocli.deployment.logs import deployment_logs
 from riocli.deployment.ssh import ssh_init, ssh_deployment
 from riocli.deployment.status import status
 from riocli.deployment.wait import wait_for_deployment
+from riocli.deployment.execute import execute_command
 
 
 @click.group(
@@ -44,3 +45,4 @@ deployment.add_command(wait_for_deployment)
 deployment.add_command(status)
 deployment.add_command(ssh_deployment)
 deployment.add_command(ssh_init)
+deployment.add_command(execute_command)

--- a/riocli/deployment/execute.py
+++ b/riocli/deployment/execute.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import click
+import typing
+
+from riocli.deployment.util import name_to_guid, select_details
+from riocli.utils.execute import run_on_cloud
+
+
+@click.command('execute')
+@click.option('--component', 'component_name', default=None)
+@click.option('--exec', 'exec_name', default=None)
+@click.argument('deployment-name', type=str)
+@click.argument('command', nargs=-1)
+@name_to_guid
+def execute_command(component_name: str, exec_name: str, deployment_name: str, deployment_guid: str, command: typing.List[str]) -> None:
+    """
+    Execute commands on cloud deployment
+    """
+    try:
+        comp_id, exec_id, pod_name = select_details(deployment_guid, component_name, exec_name)
+        stdout, stderr = run_on_cloud(deployment_guid, comp_id, exec_id, pod_name, command)
+        if stderr:
+            click.secho(stderr, fg='red')
+        if stdout:
+            click.secho(stdout, fg='yellow')
+    except Exception as e:
+        click.secho(e, fg='red')
+        raise SystemExit(1)

--- a/riocli/utils/execute.py
+++ b/riocli/utils/execute.py
@@ -34,7 +34,6 @@ def run_on_cloud(deployment_guid: str, comp_id: str, exec_id: str, pod_name: str
     rest = RestClient(_run_cloud_url(config, deployment_guid)).headers(config.get_auth_header()).method(HttpMethod.PUT)
     resp = rest.execute(payload=_run_cloud_data(comp_id, exec_id, pod_name, command))
     data = json.loads(resp.text)
-    click.secho(data)
     if 'err' in data and data['err']:
         raise Exception(data['err'])
 


### PR DESCRIPTION
Users will be able to run commands on cloud deployments

### Usage


```bash
rio deployment execute [OPTIONS] DEPLOYMENT_NAME [COMMAND]...

  Execute commands on cloud deployment

Options:
  --component TEXT
  --exec TEXT
  --help            Show this message and exit.
```

**Example**

```bash
rio deployment execute nginx1  --component ngincomp --exec exenginx python3 romil.py arg1 arg2 arg3
```

### AsciiCast
[![asciicast](https://asciinema.org/a/JdRKU40sBvDkdJZSexNbrlqF1.svg)](https://asciinema.org/a/JdRKU40sBvDkdJZSexNbrlqF1)



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1117254814)
