### PR TITLE
fix(explain): adds missing sections in deployment examples

### DIFF
--- a/riocli/apply/manifests/deployment-nonros-cloud.yaml
+++ b/riocli/apply/manifests/deployment-nonros-cloud.yaml
@@ -33,3 +33,12 @@ spec:
     - depends:
         kind: managedservice
         nameOrGUID: "managedservice"
+  features:
+    vpn:
+      enabled: true
+    params:
+      enabled: true
+      trees:
+        - config01
+        - config02
+      disableSync: false

--- a/riocli/apply/manifests/deployment-ros-cloud.yaml
+++ b/riocli/apply/manifests/deployment-ros-cloud.yaml
@@ -43,6 +43,15 @@ spec:
     - depends:
         kind: managedservice
         nameOrGUID: "managedservice"
+  features:
+    vpn:
+      enabled: true
+    params:
+      enabled: true
+      trees:
+        - config01
+        - config02
+      disableSync: false
   rosBagJobs:
     - name: "testbag1" # Required
       recordOptions: # Required

--- a/riocli/apply/manifests/deployment.yaml
+++ b/riocli/apply/manifests/deployment.yaml
@@ -43,6 +43,15 @@ spec:
     - depends:
         kind: managedservice
         nameOrGUID: "managedservice"
+  features:
+    vpn:
+      enabled: true
+    params:
+      enabled: true
+      trees:
+        - config01
+        - config02
+      disableSync: false
   rosBagJobs:
     - name: "testbag1" # Required
       recordOptions: # Required
@@ -124,6 +133,15 @@ spec:
     - depends:
         kind: managedservice
         nameOrGUID: "managedservice"
+  features:
+    vpn:
+      enabled: true
+    params:
+      enabled: true
+      trees:
+        - config01
+        - config02
+      disableSync: false
 ---
 apiVersion: apiextensions.rapyuta.io/v1
 kind: Deployment


### PR DESCRIPTION
### Description
This pull request adds missing examples for deployments with features, i.e. `vpn`, `cloud-params`.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1129331874)
