### PR TITLE
:bug: fix(package): validates maximum cpu limit for device executables

### DIFF
--- a/riocli/jsonschema/schemas/package-schema.yaml
+++ b/riocli/jsonschema/schemas/package-schema.yaml
@@ -133,6 +133,7 @@ definitions:
           cpu:
             type: number
             minimum: 0
+            maximum: 256
           memory:
             type: number
             minimum: 0


### PR DESCRIPTION
## Description
Describe the PR

## Testing
Use the below manifest to create a package

```yaml
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "Package"
metadata:
  name: "device-nginx-with-limits2"
  version: "1.0.0"
  labels:
    app: test
spec:
  runtime: "device"
  device:
    arch: "amd64"
    restart: "always"
  ros:
    enabled: True
    version: "melodic"
  executables:
    - name: "exec"
      type: docker
      runAsBash: False
      docker:
        image: "debian:latest"
      command: "sleep infinity"
      limits:
        cpu: 257
        memory: 512
```

Sample response

```bash
    pipenv run python -m riocli apply /home/romilsh/PycharmProjects/rapyuta-io-cli/examples/romil_test.yaml
    ----- Files Processed ----
    /home/romilsh/PycharmProjects/rapyuta-io-cli/examples/romil_test.yaml
                           Resource Context

    - - -
    Expected Time (mins)         0.05
    Files                         1
    Resources                     1

    Resource                           Action     Expected Time (mins)

    - - -
    package:device-nginx-with-limits2  CREATE             0.05

    Do you want to proceed? [Y/n]: y
    [Err] Object "package:device-nginx-with-limits2" apply failed. Apply will not progress further.
    Aliases for entries in sys.path:
        <sitepkg>: /home/romilsh/.local/share/virtualenvs/rapyuta-io-cli-tTirRRdF/lib/python3.8/site-packages
        <pwd>    : /home/romilsh/PycharmProjects/rapyuta-io-cli
        <py>     : /usr/lib/python3.8
    Traceback (most recent call last):
        <py>/runpy.py                   _run_module_as_main   194: return _run_code(code, main_globals, None,
        <py>/runpy.py                   _run_code              87: exec(code, run_globals)
        <pwd>/riocli/**main**.py        <module>               18: cli()
        <sitepkg>/click/core.py         **call**             1130: return self.main(_args, *_kwargs)
        <sitepkg>/click/core.py         main                 1055: rv = self.invoke(ctx)
        <sitepkg>/click/core.py         invoke               1657: return _process_result(sub_ctx.command.invoke(sub_ctx))
        <sitepkg>/click/core.py         invoke               1404: return ctx.invoke(self.callback, **ctx.params)
        <sitepkg>/click/core.py         invoke                760: return __callback(_args, *_kwargs)
        <pwd>/riocli/apply/**init**.py  apply                  89: rc.apply(dryrun=dryrun, workers=workers)
        <pwd>/riocli/apply/parse.py     apply                  88: return self.apply_async(_args, *_kwargs)
        <pwd>/riocli/apply/parse.py     apply_async           124: raise Exception(done_obj)
    Exception: {'runtime': 'device', 'device': {'arch': 'amd64', 'restart': 'always'}, 'ros': {'enabled': True, 'version': 'melodic', 'inboundScopedTargeted': False}, 'executables': [{'name': 'exec', 'type': 'docker', 'runAsBash': False, 'docker': {'image': 'debian:latest'}, 'command': 'sleep infinity', 'limits': {'cpu': 257, 'memory': 512}, 'simulation': False}]} is not valid under any of the given schemas

    Failed validating 'oneOf' in schema['properties']['spec']['dependencies']['runtime']:
        {'oneOf': [{'properties': {'device': {'$ref': '#/definitions/deviceComponentInfoSpec',
                                              'type': 'object'},
                                   'environmentArgs': {'items': {'$ref': '#/definitions/environmentSpec'},
                                                       'type': 'array'},
                                   'executables': {'items': {'$ref': '#/definitions/deviceExecutableSpec'},
                                                   'type': 'array'},
                                   'rosBagJobs': {'items': {'$ref': '#/definitions/deviceROSBagJobSpec'},
                                                  'type': 'array'},
                                   'runtime': {'enum': ['device']}}},
                   {'properties': {'cloud': {'$ref': '#/definitions/cloudComponentInfoSpec',
                                             'type': 'object'},
                                   'endpoints': {'items': {'$ref': '#/definitions/endpointSpec'},
                                                 'type': 'array'},
                                   'environmentVars': {'items': {'$ref': '#/definitions/environmentSpec'},
                                                       'type': 'array'},
                                   'executables': {'items': {'$ref': '#/definitions/cloudExecutableSpec'},
                                                   'type': 'array'},
                                   'rosBagJobs': {'items': {'$ref': '#/definitions/cloudROSBagJobSpec'},
                                                  'type': 'array'},
                                   'runtime': {'enum': ['cloud']}},
                    'required': ['cloud']}]}

    On instance['spec']:
        {'device': {'arch': 'amd64', 'restart': 'always'},
         'executables': [{'command': 'sleep infinity',
                          'docker': {'image': 'debian:latest'},
                          'limits': {'cpu': 257, 'memory': 512},
                          'name': 'exec',
                          'runAsBash': False,
                          'simulation': False,
                          'type': 'docker'}],
         'ros': {'enabled': True,
                 'inboundScopedTargeted': False,
                 'version': 'melodic'},
         'runtime': 'device'}
```



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1138814942)
