### PR TITLE
✨ feat: adds command to update the CLI

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ directory-tree = ">=0.0.3.1"
 yaspin = ">=2.3.0"
 jsonschema = ">=4.0.0"
 waiting = ">=1.4.1"
+semver = ">=3.0.0"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "374a231f04437bf496044afe3f38f7a2866dc105a0c58f6e6b532c23d63c0390"
+            "sha256": "524b510cf2b931a06bfcfb40a52847146d281ad1f70341b62a296edde40e8ffd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -425,6 +425,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
+        },
+        "semver": {
+            "hashes": [
+                "sha256:2a23844ba1647362c7490fe3995a86e097bb590d16f0f32dfc383008f19e4cdf",
+                "sha256:9ec78c5447883c67b97f98c3b6212796708191d22e4ad30f4570f840171cbce1"
+            ],
+            "index": "pypi",
+            "version": "==3.0.1"
         },
         "setuptools": {
             "hashes": [

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -28,6 +28,7 @@ from riocli.build import build
 from riocli.chart import chart
 from riocli.completion import completion
 from riocli.config import Configuration
+from riocli.constants import Colors, Symbols
 from riocli.deployment import deployment
 from riocli.device import device
 from riocli.disk import disk
@@ -42,6 +43,12 @@ from riocli.secret import secret
 from riocli.shell import shell, deprecated_repl
 from riocli.static_route import static_route
 from riocli.usergroup import usergroup
+from riocli.utils import (
+    check_for_updates,
+    pip_install_cli,
+    is_pip_installation,
+    update_appimage,
+)
 from riocli.vpn import vpn
 
 
@@ -49,8 +56,8 @@ from riocli.vpn import vpn
 @click.group(
     invoke_without_command=False,
     cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="green",
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
 )
 @click.pass_context
 def cli(ctx: Context, config: str = None):
@@ -73,6 +80,38 @@ def version():
     """
     click.echo("rio {} / SDK {}".format(__version__, rapyuta_io.__version__))
     return
+
+
+@cli.command('update')
+@click.option('-f', '--force', '--silent', 'silent', is_flag=True,
+              type=click.BOOL, default=False,
+              help="Skip confirmation")
+def update(silent: bool) -> None:
+    """
+    Update the CLI to the latest version
+    """
+    available, latest = check_for_updates(__version__)
+    if not available:
+        click.secho('🎉 You are using the latest version', fg=Colors.GREEN)
+        return
+
+    click.secho('🎉 A newer version ({}) is available.'.format(latest),
+                fg=Colors.GREEN)
+
+    if not silent:
+        click.confirm('Do you want to update?', abort=True, default=False)
+
+    try:
+        if is_pip_installation():
+            pip_install_cli(version=latest)
+        else:
+            update_appimage(version=latest)
+    except Exception as e:
+        click.secho('{} Failed to update the CLI'.format(e), fg=Colors.RED)
+        raise SystemExit(1) from e
+
+    click.secho('{} Update successful!'.format(Symbols.SUCCESS),
+                fg=Colors.GREEN)
 
 
 cli.add_command(apply)

--- a/riocli/utils/__init__.py
+++ b/riocli/utils/__init__.py
@@ -12,18 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import os
 import random
 import shlex
 import string
 import subprocess
+import sys
 import typing
+from pathlib import Path
 from shutil import get_terminal_size
+from tempfile import TemporaryDirectory
 from uuid import UUID
 
 import click
+import requests
+import semver
 import yaml
 from click_help_colors import HelpColorsGroup
+from munch import munchify
 from tabulate import tabulate
+
+from riocli.constants import Colors, Symbols
 
 
 def inspect_with_format(obj: typing.Any, format_type: str):
@@ -81,11 +90,13 @@ riocli_group_opts = {
 
 
 def random_string(letter_count, digit_count):
-    str1 = ''.join((random.choice(string.ascii_letters) for x in range(letter_count)))
+    str1 = ''.join(
+        (random.choice(string.ascii_letters) for x in range(letter_count)))
     str1 += ''.join((random.choice(string.digits) for x in range(digit_count)))
 
     sam_list = list(str1)  # it converts the string to list.
-    random.shuffle(sam_list)  # It uses a random.shuffle() function to shuffle the string.
+    random.shuffle(
+        sam_list)  # It uses a random.shuffle() function to shuffle the string.
     final_string = ''.join(sam_list)
     return final_string
 
@@ -118,7 +129,8 @@ def is_valid_uuid(uuid_to_test, version=4):
     return str(uuid_obj) == uuid_to_test
 
 
-def tabulate_data(data: typing.List[typing.List], headers: typing.List[str] = None):
+def tabulate_data(data: typing.List[typing.List],
+                  headers: typing.List[str] = None):
     """
     Prints data in tabular format
     """
@@ -138,3 +150,93 @@ def print_separator(color: str = 'blue'):
     """
     col, _ = get_terminal_size()
     click.secho(" " * col, bg=color)
+
+
+def is_pip_installation() -> bool:
+    return 'python' in sys.executable
+
+
+def check_for_updates(current_version: str) -> tuple[bool, str]:
+    try:
+        package_info = requests.get(
+            'https://pypi.org/pypi/rapyuta-io-cli/json').json()
+    except Exception as e:
+        click.secho('Failed to fetch upstream package info: {}'.format(e),
+                    fg=Colors.RED)
+        raise SystemExit(1) from e
+
+    upstream_version = package_info.get('info', {}).get('version')
+
+    current_version = semver.Version.parse(current_version)
+    available = semver.Version.parse(upstream_version).compare(current_version)
+
+    return available > 0, upstream_version
+
+
+def pip_install_cli(
+        version: str,
+        force_reinstall: bool = False,
+) -> subprocess.CompletedProcess:
+    """
+    Installs the given rapyuta-io-cli version using pip
+    """
+    if not version:
+        raise ValueError('version cannot by empty.')
+
+    try:
+        semver.Version.parse(version)
+    except ValueError as err:
+        raise err
+
+    package_name = 'rapyuta-io-cli=={}'.format(version)
+
+    # https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
+    command = [sys.executable, '-m', 'pip', 'install', package_name]
+    if force_reinstall:
+        command.append('--force-reinstall')
+
+    return subprocess.run(command, check=True)
+
+
+def update_appimage(version: str):
+    """
+    Updates the AppImage locally
+    """
+    if not version:
+        raise ValueError('version cannot be empty')
+
+    if os.getuid() != 0:
+        click.secho(
+            '{} Please run this as the root user.'.format(Symbols.WARNING),
+            fg=Colors.YELLOW)
+        raise SystemExit(1)
+
+    # URL to get the latest release metadata
+    url = 'https://api.github.com/repos/rapyuta-robotics/rapyuta-io-cli/releases/latest'
+
+    try:
+        response = requests.get(url)
+        data = munchify(response.json())
+    except Exception as e:
+        click.secho('Failed to fetch release info: {}'.format(e),
+                    fg=Colors.RED)
+        raise SystemExit(1) from e
+
+    asset = None
+    for a in data.get('assets', []):
+        if 'AppImage' in a.name and version in a.name:
+            asset = a
+            break
+
+    if asset is None:
+        raise Exception(
+            'Failed to retrieve the download URL for the latest AppImage')
+
+    with TemporaryDirectory() as tmp:
+        # Download and save the binary in a temp dir
+        response = requests.get(asset.browser_download_url)
+        save_to = Path(tmp) / 'rio'
+        save_to.write_bytes(response.content)
+        os.chmod(save_to, 0o755)
+        # Now replace the current executable with the new file
+        os.rename(save_to, sys.executable)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
         "directory-tree>=0.0.3.1",
         "yaspin>=2.3.0",
         "jsonschema>=4.0.0",
-        "waiting>=1.4.1"
+        "waiting>=1.4.1",
+        "semver>=3.0.0",
     ],
     setup_requires=["flake8"],
 )


### PR DESCRIPTION
## Description
This commit adds a new command to update the CLI to the latest version.

```bash
Usage: rio update [OPTIONS]

  Update the CLI to the latest version

Options:
  -f, --force, --silent  Skip confirmation
  --help                 Show this message and exit.
```

#### Why add this command?
This will make it easier for the users of the CLI to upgrade their local installation with a 
simple command.

## Testing
### AppImage Update
```
11:55:26 pallab@pop-os appimages (1) 
→ rio version
rio 0.6.0 / SDK 1.10.0
11:55:34 pallab@pop-os appimages (1) 
→ rio update -f
⚠ Please run this as the root user.
11:55:40 pallab@pop-os appimages (1) 
→ sudo rio update -f
🎉 A newer version (3.1.0) is available.
✔ Update successful!
11:55:48 pallab@pop-os appimages (1) 
→ rio version
rio 3.1.0 / SDK 1.10.0
11:55:56 pallab@pop-os appimages (1)
```
### Python Package Update
```
→ pipenv run python -m riocli update -f
🎉 A newer version (3.1.0) is available.
Collecting rapyuta-io-cli==3.1.0
  Downloading rapyuta_io_cli-3.1.0-py3-none-any.whl (233 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 233.2/233.2 kB 3.5 MB/s eta 0:00:00
Collecting argparse>=1.4.0 (from rapyuta-io-cli==3.1.0)
  Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Requirement already satisfied: click-completion>=0.5.2 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (0.5.2)
Requirement already satisfied: click-help-colors>=0.9.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (0.9.1)
Requirement already satisfied: click-plugins>=1.1.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (1.1.1)
Requirement already satisfied: click-repl>=0.2.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (0.3.0)
Requirement already satisfied: click-spinner>=0.1.10 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (0.1.10)
Requirement already satisfied: click>=8.0.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (8.1.3)
Requirement already satisfied: dictdiffer>=0.9.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (0.9.0)
Requirement already satisfied: directory-tree>=0.0.3.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (0.0.3.1)
Requirement already satisfied: graphlib-backport>=1.0.3 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (1.0.3)
Requirement already satisfied: jinja2>=3.0.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (3.1.2)
Requirement already satisfied: jsonschema>=4.0.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (4.17.3)
Requirement already satisfied: munch>=2.4.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (4.0.0)
Requirement already satisfied: pretty-traceback>=2022.1018 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (2022.1018)
Requirement already satisfied: pyrfc3339>=1.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (1.1)
Requirement already satisfied: python-dateutil>=2.8.2 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (2.8.2)
Requirement already satisfied: pytz in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (2023.3)
Requirement already satisfied: pyyaml>=5.4.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (6.0)
Requirement already satisfied: rapyuta-io>=1.10.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (1.10.0)
Requirement already satisfied: requests>=2.20.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (2.31.0)
Requirement already satisfied: setuptools in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (68.0.0)
Requirement already satisfied: six>=1.13.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (1.16.0)
Requirement already satisfied: tabulate>=0.8.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (0.9.0)
Requirement already satisfied: urllib3>=1.23 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (2.0.3)
Requirement already satisfied: waiting>=1.4.1 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (1.4.1)
Requirement already satisfied: yaspin>=2.3.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from rapyuta-io-cli==3.1.0) (2.3.0)
Requirement already satisfied: shellingham in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from click-completion>=0.5.2->rapyuta-io-cli==3.1.0) (1.5.0.post1)
Requirement already satisfied: prompt-toolkit>=3.0.36 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from click-repl>=0.2.0->rapyuta-io-cli==3.1.0) (3.0.39)
Requirement already satisfied: MarkupSafe>=2.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from jinja2>=3.0.1->rapyuta-io-cli==3.1.0) (2.1.3)
Requirement already satisfied: attrs>=17.4.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from jsonschema>=4.0.0->rapyuta-io-cli==3.1.0) (23.1.0)
Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from jsonschema>=4.0.0->rapyuta-io-cli==3.1.0) (0.19.3)
Requirement already satisfied: colorama>=0.4 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from pretty-traceback>=2022.1018->rapyuta-io-cli==3.1.0) (0.4.6)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from requests>=2.20.0->rapyuta-io-cli==3.1.0) (2.1.1)
Requirement already satisfied: idna<4,>=2.5 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from requests>=2.20.0->rapyuta-io-cli==3.1.0) (3.4)
Requirement already satisfied: certifi>=2017.4.17 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from requests>=2.20.0->rapyuta-io-cli==3.1.0) (2023.5.7)
Requirement already satisfied: termcolor<3.0,>=2.2 in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from yaspin>=2.3.0->rapyuta-io-cli==3.1.0) (2.3.0)
Requirement already satisfied: wcwidth in /home/pallab/.local/share/virtualenvs/rapyuta-io-cli-eJqwJnu2/lib/python3.10/site-packages (from prompt-toolkit>=3.0.36->click-repl>=0.2.0->rapyuta-io-cli==3.1.0) (0.2.6)
Installing collected packages: argparse, rapyuta-io-cli
  Attempting uninstall: rapyuta-io-cli
    Found existing installation: rapyuta-io-cli 0.6.0
    Uninstalling rapyuta-io-cli-0.6.0:
      Successfully uninstalled rapyuta-io-cli-0.6.0
Successfully installed argparse-1.4.0 rapyuta-io-cli-3.1.0
✔ Update successful!
```

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1139934830)
