### PR TITLE
:bug: fix(jsonschema): updates the projectGUID regex pattern

### DIFF
--- a/riocli/jsonschema/schemas/build-schema.yaml
+++ b/riocli/jsonschema/schemas/build-schema.yaml
@@ -39,7 +39,7 @@ definitions:
       - name
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   buildGUID:
     type: string
     pattern: "^build-[a-z]{24}$"

--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -369,7 +369,7 @@ definitions:
     pattern: "^org-[a-z]{24}$"
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   secretGUID:
     type: string
     pattern: "^secret-[a-z]{24}$"

--- a/riocli/jsonschema/schemas/device-schema.yaml
+++ b/riocli/jsonschema/schemas/device-schema.yaml
@@ -98,7 +98,7 @@ definitions:
       type: string
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   uuid:
     type: string
     pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"

--- a/riocli/jsonschema/schemas/disk-schema.yaml
+++ b/riocli/jsonschema/schemas/disk-schema.yaml
@@ -38,7 +38,7 @@ definitions:
       - name
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   diskGUID:
     type: string
     pattern: "^disk-[a-z]{24}$"

--- a/riocli/jsonschema/schemas/managedservice-schema.yaml
+++ b/riocli/jsonschema/schemas/managedservice-schema.yaml
@@ -38,7 +38,7 @@ definitions:
       - name
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   stringMap:
     type: object
     additionalProperties:

--- a/riocli/jsonschema/schemas/network-schema.yaml
+++ b/riocli/jsonschema/schemas/network-schema.yaml
@@ -99,7 +99,7 @@ definitions:
     pattern: "^network-[a-z]{24}$"
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   stringMap:
     type: object
     additionalProperties:

--- a/riocli/jsonschema/schemas/package-schema.yaml
+++ b/riocli/jsonschema/schemas/package-schema.yaml
@@ -638,7 +638,7 @@ definitions:
     pattern: "^org-[a-z]{24}$"
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   secretGUID:
     type: string
     pattern: "^secret-[a-z]{24}$"

--- a/riocli/jsonschema/schemas/primitives.yaml
+++ b/riocli/jsonschema/schemas/primitives.yaml
@@ -9,7 +9,7 @@ definitions:
     pattern: "^org-[a-z]{24}$"
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   secretGUID:
     type: string
     pattern: "^secret-[a-z]{24}$"

--- a/riocli/jsonschema/schemas/project-schema.yaml
+++ b/riocli/jsonschema/schemas/project-schema.yaml
@@ -43,7 +43,7 @@ definitions:
       - name
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   organizationGUID:
     type: string
     pattern: "^org-[a-z]{24}$"

--- a/riocli/jsonschema/schemas/secret-schema.yaml
+++ b/riocli/jsonschema/schemas/secret-schema.yaml
@@ -38,7 +38,7 @@ definitions:
       - name
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   secretGUID:
     type: string
     pattern: "^secret-[a-z]{24}$"

--- a/riocli/jsonschema/schemas/static_route-schema.yaml
+++ b/riocli/jsonschema/schemas/static_route-schema.yaml
@@ -36,7 +36,7 @@ definitions:
       - name
   projectGUID:
     type: string
-    pattern: "^project-[a-z]{24}$"
+    pattern: "^project-([a-z0-9]{20}|[a-z]{24})$"
   staticRouteGUID:
     type: string
     pattern: "^staticroute-[a-z]{24}$"


### PR DESCRIPTION
## Description
This commit fixes the project guid regex pattern used in some schemas per the latest v2 project GUID changes. The guid that is generated now is alphanumeric with fewer characters.