### PR TITLE
✨ feat(deployment): adds flags for retry count and sleep interval

### DIFF
--- a/riocli/apply/__init__.py
+++ b/riocli/apply/__init__.py
@@ -47,11 +47,17 @@ from riocli.apply.util import process_files_values_secrets
 @click.option('-f', '--force', '--silent', 'silent', is_flag=True,
               type=click.BOOL, default=False,
               help="Skip confirmation")
+@click.option('--retry-count', '-rc', type=int, default=50,
+              help="Number of retries before a resource creation times out status, defaults to 50")
+@click.option('--retry-interval', '-ri', type=int, default=6,
+              help="Interval between retries defaults to 6")
 @click.argument('files', nargs=-1)
 def apply(
         values: str,
         secrets: str,
         files: Iterable[str],
+        retry_count: int,
+        retry_interval: int,
         dryrun: bool = False,
         workers: int = 6,
         silent: bool = False,
@@ -86,7 +92,7 @@ def apply(
     if not silent and not dryrun:
         click.confirm("Do you want to proceed?", default=True, abort=True)
 
-    rc.apply(dryrun=dryrun, workers=workers)
+    rc.apply(dryrun=dryrun, workers=workers, retry_count=retry_count, retry_interval=retry_interval)
 
 
 @click.command(

--- a/riocli/build/model.py
+++ b/riocli/build/model.py
@@ -32,7 +32,7 @@ class Build(Model):
 
         return obj
 
-    def create_object(self, client: Client) -> v1Build:
+    def create_object(self, client: Client, **kwargs) -> v1Build:
         build = client.create_build(build=self.to_v1())
         return build
 

--- a/riocli/device/model.py
+++ b/riocli/device/model.py
@@ -33,7 +33,7 @@ class Device(Model):
 
         return obj
 
-    def create_object(self, client: Client) -> v1Device:
+    def create_object(self, client: Client, **kwargs) -> v1Device:
         device = client.create_device(self.to_v1())
         return device
 

--- a/riocli/managedservice/model.py
+++ b/riocli/managedservice/model.py
@@ -32,7 +32,7 @@ class ManagedService(Model):
         except Exception:
             return False
 
-    def create_object(self, client: Client) -> typing.Any:
+    def create_object(self, client: Client, **kwargs) -> typing.Any:
         client = new_v2_client()
 
         ms = unmunchify(self)

--- a/riocli/model/base.py
+++ b/riocli/model/base.py
@@ -45,7 +45,7 @@ class Model(ABC, Munch):
                 message_with_prompt("⌛ Create {}:{}".format(
                     self.kind.lower(), self.metadata.name), fg='yellow')
                 if not dryrun:
-                    result = self.create_object(client)
+                    result = self.create_object(client, **kwargs)
                     message_with_prompt("✅ Created {}:{}".format(
                         self.kind.lower(), self.metadata.name), fg='green')
                     return result
@@ -99,7 +99,7 @@ class Model(ABC, Munch):
         pass
 
     @abstractmethod
-    def create_object(self, client: Client) -> typing.Any:
+    def create_object(self, client: Client, **kwargs) -> typing.Any:
         pass
 
     @abstractmethod

--- a/riocli/network/model.py
+++ b/riocli/network/model.py
@@ -38,14 +38,17 @@ class Network(Model):
         except NetworkNotFound:
             return False
 
-    def create_object(self, client: Client) -> Union[NativeNetwork, RoutedNetwork]:
+    def create_object(self, client: Client, **kwargs) -> Union[NativeNetwork, RoutedNetwork]:
+        retry_count = int(kwargs.get('retry_count'))
+        retry_interval = int(kwargs.get('retry_interval'))
+
         if self.spec.type == 'routed':
             network = self._create_routed_network(client)
-            network.poll_routed_network_till_ready()
+            network.poll_routed_network_till_ready(retry_count=retry_count, sleep_interval=retry_interval)
             return network
 
         network = client.create_native_network(self.to_v1(client))
-        network.poll_native_network_till_ready()
+        network.poll_native_network_till_ready(retry_count=retry_count, sleep_interval=retry_interval)
         return network
 
     def update_object(self, client: Client, obj: Union[RoutedNetwork, NativeNetwork]) -> Any:

--- a/riocli/package/model.py
+++ b/riocli/package/model.py
@@ -40,7 +40,7 @@ class Package(Model):
 
         return obj
 
-    def create_object(self, client: Client):
+    def create_object(self, client: Client, **kwargs):
         pkg_object = munchify({
             'name': 'default',
             'packageVersion': 'v1.0.0',

--- a/riocli/project/model.py
+++ b/riocli/project/model.py
@@ -38,7 +38,7 @@ class Project(Model):
 
         return obj
 
-    def create_object(self, client: Client) -> typing.Any:
+    def create_object(self, client: Client, **kwargs) -> typing.Any:
         client = new_v2_client()
 
         # convert to a dict and remove the ResolverCache

--- a/riocli/secret/model.py
+++ b/riocli/secret/model.py
@@ -34,7 +34,7 @@ class Secret(Model):
 
         return secret
 
-    def create_object(self, client: Client) -> v1Secret:
+    def create_object(self, client: Client, **kwargs) -> v1Secret:
         secret = client.create_secret(self.to_v1())
         return secret
 

--- a/riocli/static_route/model.py
+++ b/riocli/static_route/model.py
@@ -32,7 +32,7 @@ class StaticRoute(Model):
 
         return static_route
 
-    def create_object(self, client: Client) -> v1StaticRoute:
+    def create_object(self, client: Client, **kwargs) -> v1StaticRoute:
         static_route = client.create_static_route(self.metadata.name)
         return static_route
 


### PR DESCRIPTION
## About
When we create deployments in rapyuta io, we employ a polling mechanism that polls for the deployment status at regular intervals until the deployment reaches a succeeded or failed state. 

Although the poll count and the interval between successive polls were configurable, however the provision to do so was lacking in the CLI. This PR resolves that by adding two flags `--retry-count` and `--retry-sleep-interval` in the apply command. 

## Screencast 


https://github.com/rapyuta-robotics/rapyuta-io-cli/assets/5301901/d192f48c-76da-4cb9-bd11-ec2b8a1b17d7


