### PR TITLE
🚀 perf(deployment): polls deployment till provisioning phase

### DIFF
--- a/riocli/deployment/model.py
+++ b/riocli/deployment/model.py
@@ -17,7 +17,7 @@ import typing
 import click
 from rapyuta_io import Client
 from rapyuta_io.clients.catalog_client import Package
-from rapyuta_io.clients.deployment import DeploymentNotRunningException
+from rapyuta_io.clients.deployment import DeploymentNotRunningException, DeploymentPhaseConstants
 from rapyuta_io.clients.native_network import NativeNetwork
 from rapyuta_io.clients.package import ProvisionConfiguration, RestartPolicy, \
     ExecutableMount
@@ -220,7 +220,7 @@ class Deployment(Model):
         deployment = pkg.provision(self.metadata.name, provision_config)
 
         try:
-            deployment.poll_deployment_till_ready(retry_count=retry_count, sleep_interval=retry_interval)
+            deployment.poll_deployment_till_ready(retry_count=retry_count, sleep_interval=retry_interval, ready_phases=[DeploymentPhaseConstants.PROVISIONING.value])
         except DeploymentNotRunningException as e:
             raise Exception(process_deployment_errors(e)) from e
         except Exception as e:

--- a/riocli/deployment/util.py
+++ b/riocli/deployment/util.py
@@ -127,8 +127,6 @@ def add_mount_volume_provision_config(provision_config, component_name, device, 
             isinstance(mount, ExecutableMount) for mount in executable_mounts):
         raise InvalidParameterException(
             'executable_mounts must be a list of rapyuta_io.clients.package.ExecutableMount')
-    if not device.is_online():
-        raise OperationNotAllowedError('Device should be online')
     if device.get_runtime() != Device.DOCKER_COMPOSE and not device.is_docker_enabled():
         raise OperationNotAllowedError('Device must be a {} device'.format(Device.DOCKER_COMPOSE))
     component_params = provision_config.parameters.get(component_id)


### PR DESCRIPTION
This PR uses the new SDK changes where poll deployment till ready state is configurable as per deployment phases. 
(https://github.com/rapyuta-robotics/rapyuta-io-sdk/pull/60). Made changes in cli to  poll deployment till provisioning phase. Once the phase of deployment reaches provisioning, it would be available by other deployments to bind. 