### PR TITLE
:bug: fix(deployment): Deployment with native network

### DIFF
--- a/riocli/apply/resolver.py
+++ b/riocli/apply/resolver.py
@@ -125,7 +125,7 @@ class ResolverCache(object, metaclass=_Singleton):
             "staticroute": lambda x: munchify(x)['guid'],
             "build": lambda x: munchify(x)['guid'],
             "deployment": lambda x: munchify(x)['deploymentId'],
-            "network": lambda x: munchify(x)['guid'],
+            "network": lambda x: munchify(x).guid,
             # This is only temporarily like this
             "disk": lambda x: munchify(x)['internalDeploymentGUID'],
             "device": lambda x: munchify(x)['uuid'],


### PR DESCRIPTION
Creation of deployments with native networks were failing with the following error
```
Exception: 'NativeNetwork' object is not subscriptable
```

Native networks and routed networks are returned as class objects by the Rapyuta IO SDK, however the CLI was handling it as a python dictionary. 

This PR resolves the issue by fixing the incorrect syntax. 
