### PR TITLE
✨ feat(organization): adds command to list users

### DIFF
--- a/riocli/organization/__init__.py
+++ b/riocli/organization/__init__.py
@@ -17,6 +17,7 @@ from click_help_colors import HelpColorsGroup
 from riocli.constants import Colors
 from riocli.organization.list import list_organizations
 from riocli.organization.select import select_organization
+from riocli.organization.users import list_users
 
 
 @click.group(
@@ -32,5 +33,6 @@ def organization() -> None:
     pass
 
 
+organization.add_command(list_users)
 organization.add_command(list_organizations)
 organization.add_command(select_organization)

--- a/riocli/organization/users.py
+++ b/riocli/organization/users.py
@@ -1,0 +1,47 @@
+# Copyright 2023 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from click_help_colors import HelpColorsCommand
+
+from riocli.constants import Colors, Symbols
+from riocli.organization.utils import get_organization_details
+from riocli.utils import tabulate_data
+from riocli.utils.context import get_root_context
+
+
+@click.command(
+    'users',
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+@click.pass_context
+def list_users(ctx: click.Context) -> None:
+    """
+    Lists all users in the organization.
+    """
+    ctx = get_root_context(ctx)
+
+    try:
+        organization = get_organization_details(ctx.obj.data['organization_id'])
+    except Exception as e:
+        click.secho('{} Failed to get organization details'.format(Symbols.ERROR), fg=Colors.RED)
+        raise SystemExit(1) from e
+
+    users = organization.get('users')
+
+    data = [[u['guid'], '{} {}'.format(u['firstName'], u['lastName']), u['emailID'], u['state']] for u in users]
+
+    tabulate_data(data, headers=['GUID', 'Name', 'EmailID', 'Status'])

--- a/riocli/organization/utils.py
+++ b/riocli/organization/utils.py
@@ -24,7 +24,7 @@ def _api_call(
         path: typing.Union[str, None] = None,
         payload: typing.Union[typing.Dict, None] = None,
         load_response: bool = True,
-) -> typing.Any:
+) -> typing.Dict:
     config = Configuration()
     coreapi_host = config.data.get(
         'core_api_host',
@@ -51,5 +51,5 @@ def _api_call(
     return data
 
 
-def get_organization_details(organization_guid):
+def get_organization_details(organization_guid: str) -> typing.Dict:
     return _api_call(HttpMethod.GET, '{}/get'.format(organization_guid))


### PR DESCRIPTION
## Description
```
Usage: python -m riocli organization users [OPTIONS]

  Lists all users in the organization.

Options:
  --help  Show this message and exit.
```
## Testing
```
→ pipenv run python -m riocli organization users
GUID                                  Name        EmailID                          Status
------------------------------------  ----------  -------------------------------  ---------
fa224b22-9568-4ae7-890f-8c2175bd375b  QA Rapyuta  qa.rapyuta+e2e@gmail.com         ACTIVATED
1f9b5b3f-89a5-4620-bc5c-85de68fab147  aditya jha  aditya.jha@rapyuta-robotics.com  ACTIVATED
e41060bf-f7f2-49e5-ad98-a481328faf40  test test   test.test@rapyuta-robotics.com   ACTIVATED

```