### PR TITLE
🐛 fix(jsonschema): adds regex pattern to usergroup schema

### DIFF
--- a/riocli/jsonschema/schemas/usergroup-schema.yaml
+++ b/riocli/jsonschema/schemas/usergroup-schema.yaml
@@ -28,6 +28,7 @@ definitions:
     properties:
       name:
         type: string
+        pattern: "^[a-zA-Z][a-z A-Z0-9-_]{2,63}$"
       guid:
         $ref: "#/definitions/uuid"
       creator:


### PR DESCRIPTION
## Description
The `usergroup` jsonschema had no validation on the group name. This PR fixes that.

## Testing
```
→ pipenv run python -m riocli apply ~/workspace/playground/riocli-manifests/usergroup.yaml --dryrun
----- Files Processed ----
/home/pallab/workspace/playground/riocli-manifests/usergroup.yaml
                       Resource Context
--------------------  ------------------
Expected Time (mins)         0.08
Files                         1
Resources                     1
                                                                                                                                                                                      
Resource      Action     Expected Time (mins)
------------  --------  ----------------------
usergroup:aa  CREATE             0.08
                                                                                                                                                                                      
⠋ Applying... (0:00:00.00)[Err] Object "usergroup:aa" apply failed. Apply will not progress further.
✘ Apply failed. Error: 'aa' does not match '^[a-zA-Z][a-z A-Z0-9-_]{2,61}$'

Failed validating 'pattern' in schema['properties']['metadata']['properties']['name']:
    {'pattern': '^[a-zA-Z][a-z A-Z0-9-_]{2,62}$', 'type': 'string'}

On instance['metadata']['name']:
    'aa' (0:00:00.01)

```