### PR TITLE
✨ feat(deployment): exposes healthcheck probes for device deployments

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/riocli/apply/manifests/package-nonros-device.yaml
+++ b/riocli/apply/manifests/package-nonros-device.yaml
@@ -20,6 +20,15 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        exec:
+          command:
+            - "shell-cmd"
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       build:
         depends:
           kind: build
@@ -31,6 +40,16 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe:
+        http:
+          path: "/"
+          port: 90
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
+
       docker:
         image: "busybox:latest"
         imagePullPolicy: "Always" # Always, Never, IfNotPresent(default)

--- a/riocli/apply/manifests/package-ros-device-no-rosbag.yaml
+++ b/riocli/apply/manifests/package-ros-device-no-rosbag.yaml
@@ -21,6 +21,14 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        tcp:
+          port: 999
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       build:
         depends:
           kind: build
@@ -32,6 +40,15 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        http:
+          path: "/"
+          port: 90
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       docker:
         image: "busybox:latest"
         imagePullPolicy: "Always" # Always, Never, IfNotPresent(default)

--- a/riocli/apply/manifests/package-ros-device-rosbag.yaml
+++ b/riocli/apply/manifests/package-ros-device-rosbag.yaml
@@ -21,6 +21,15 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        http:
+          path: "/"
+          port: 90
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       build:
         depends:
           kind: build
@@ -32,6 +41,15 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        exec:
+          command:
+            - "shell-cmd"
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       docker:
         image: "busybox:latest"
         imagePullPolicy: "Always" # Always, Never, IfNotPresent(default)

--- a/riocli/apply/manifests/package.yaml
+++ b/riocli/apply/manifests/package.yaml
@@ -166,6 +166,15 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        exec:
+          command:
+            - "shell-cmd"
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       build:
         depends:
           kind: build
@@ -177,6 +186,14 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        tcp:
+          port: 999
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       docker:
         image: "busybox:latest"
         imagePullPolicy: "Always" # Always, Never, IfNotPresent(default)
@@ -377,6 +394,15 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        exec:
+          command:
+            - "shell-cmd"
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       build:
         depends:
           kind: build
@@ -388,6 +414,15 @@ spec:
       limits: # Optional
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        exec:
+          command:
+            - "shell-cmd"
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       docker:
         image: "busybox:latest"
         imagePullPolicy: "Always" # Always, Never, IfNotPresent(default)
@@ -431,6 +466,15 @@ spec:
       limits:
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        exec:
+          command:
+            - "shell-cmd"
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       build:
         depends:
           kind: build
@@ -442,6 +486,15 @@ spec:
       limits:
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        exec:
+          command:
+            - "shell-cmd"
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
       docker:
         image: "busybox:latest"
         imagePullPolicy: "Always" # Always, Never, IfNotPresent(default)

--- a/riocli/jsonschema/schemas/package-schema.yaml
+++ b/riocli/jsonschema/schemas/package-schema.yaml
@@ -122,8 +122,11 @@ definitions:
           - docker
           - build
           - preInstalled
-      command:
-        type: string
+        command:
+          type: array
+          items:
+            type: string
+          description: Command to execute for the Exec probe.
       runAsBash:
         type: boolean
         default: True
@@ -137,6 +140,9 @@ definitions:
           memory:
             type: number
             minimum: 0
+      livenessProbe:
+        type: object
+        "$ref": "#/definitions/livenessProbe"
     required:
       - type
     dependencies:
@@ -734,3 +740,73 @@ definitions:
         type: string
       guid:
         type: string
+
+  livenessProbe:
+    type: object
+    properties:
+      httpGet:
+        type: object
+        properties:
+          path:
+            type: string
+            description: Path to access for the HTTP probe.
+          port:
+            type: integer
+            description: Port number for the HTTP probe.
+          schema:
+            type: string
+            default: HTTP
+            description: Scheme to use for connecting to the host.
+        required:
+          - path
+          - port
+      exec:
+        type: object
+        properties:
+          command:
+            type: array
+            items:
+              type: string
+            description: Command to execute for the Exec probe.
+        required:
+          - command
+      tcpSocket:
+        type: object
+        properties:
+          port:
+            type: integer
+            description: Port number for the TCP probe.
+        required:
+          - port
+      initialDelaySeconds:
+        type: integer
+        minimum: 1
+        default: 1
+        description: Number of seconds after the container has started before liveness probes are initiated.
+      timeoutSeconds:
+        type: integer
+        minimum: 10
+        default: 10
+        description: Number of seconds after which the probe times out.
+      periodSeconds:
+        type: integer
+        minimum: 1
+        default: 1
+        description: How often (in seconds) to perform the probe.
+      successThreshold:
+        type: integer
+        default: 3
+        minimum: 1
+        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+      failureThreshold:
+        type: integer
+        default: 3
+        minimum: 1
+        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+    oneOf:
+      - required:
+          - httpGet
+      - required:
+          - tcpSocket
+      - required:
+          - exec

--- a/riocli/package/model.py
+++ b/riocli/package/model.py
@@ -159,7 +159,6 @@ class Package(Model):
             component_obj.rosBagJobDefs = self.spec.rosBagJobs
 
         pkg_object.plans[0].components = [component_obj]
-
         return client.create_package(pkg_object)
 
     def update_object(self, client: Client, obj: typing.Any) -> typing.Any:
@@ -197,6 +196,9 @@ class Package(Model):
                 'cpu': exec.limits.get('cpu', 0.0),
                 'memory': exec.limits.get('memory', 0)
             }
+
+        if 'livenessProbe' in exec:
+            exec_object.livenessProbe = exec.livenessProbe
 
         if exec.get('runAsBash'):
             if 'command' in exec:


### PR DESCRIPTION
This commit adds support for defining liveness probe. You can set HTTP, EXEC or TCP liveness probe

Demo: https://asciinema.org/a/X6Z2IgL0XXHvSbM5rcvBtPIk1
Manifest: https://drive.google.com/file/d/19KmQ6npDzAm6LGlDkK-DxcfXnddVfwRE/view?usp=sharing 