### PR TITLE
🐛 fix: implements dummy spinner for non-tty environments

### DIFF
--- a/riocli/deployment/execute.py
+++ b/riocli/deployment/execute.py
@@ -11,12 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import sys
 import typing
 
 import click
 from click_help_colors import HelpColorsCommand
-from yaspin import kbi_safe_yaspin
+
+if sys.stdout.isatty():
+    from yaspin import kbi_safe_yaspin as Spinner
+else:
+    from riocli.utils.spinner import DummySpinner as Spinner
 
 from riocli.constants import Colors
 from riocli.deployment.util import name_to_guid, select_details
@@ -49,7 +53,7 @@ def execute_command(
     try:
         comp_id, exec_id, pod_name = select_details(deployment_guid, component_name, exec_name)
 
-        with kbi_safe_yaspin(text='Executing command `{}`...'.format(command)) as spinner:
+        with Spinner(text='Executing command `{}`...'.format(command)):
             stdout, stderr = run_on_cloud(deployment_guid, comp_id, exec_id, pod_name, command)
 
         if stderr:

--- a/riocli/device/vpn.py
+++ b/riocli/device/vpn.py
@@ -11,11 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 import typing
 
 import click
 from click_help_colors import HelpColorsCommand
-from yaspin import kbi_safe_yaspin
+
+if sys.stdout.isatty():
+    from yaspin import kbi_safe_yaspin as Spinner
+else:
+    from riocli.utils.spinner import DummySpinner as Spinner
 
 from riocli.config import new_client
 from riocli.constants import Colors
@@ -78,7 +83,7 @@ def toggle_vpn(devices: typing.List, enable: bool,
         click.echo("")  # Echo an empty line
 
         result = []
-        with kbi_safe_yaspin() as spinner:
+        with Spinner() as spinner:
             for device in final:
                 spinner.text = 'Updating VPN state on device {}'.format(
                     click.style(device.name, bold=True, fg=Colors.CYAN))

--- a/riocli/network/delete.py
+++ b/riocli/network/delete.py
@@ -63,7 +63,7 @@ def delete_network(
             raise Exception('invalid network type')
 
         spinner.text = click.style(
-            '{} deleted successfully!'.format(network_type.capitalize()),
+            '{} network deleted successfully!'.format(network_type.capitalize()),
             fg=Colors.GREEN)
         spinner.green.ok(Symbols.SUCCESS)
     except Exception as e:

--- a/riocli/parameter/apply.py
+++ b/riocli/parameter/apply.py
@@ -11,11 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 import typing
 
 import click
 from click_help_colors import HelpColorsCommand
-from yaspin import kbi_safe_yaspin
+
+if sys.stdout.isatty():
+    from yaspin import kbi_safe_yaspin as Spinner
+else:
+    from riocli.utils.spinner import DummySpinner as Spinner
 
 from riocli.config import new_client
 from riocli.constants import Colors, Symbols
@@ -79,7 +84,7 @@ def apply_configurations(
                 "Do you want to apply the configurations?",
                 default=True, abort=True)
 
-        with kbi_safe_yaspin(text='Applying parameters...') as spinner:
+        with Spinner(text='Applying parameters...'):
             response = client.apply_parameters(
                 list(device_ids.keys()),
                 list(tree_names),

--- a/riocli/parameter/delete.py
+++ b/riocli/parameter/delete.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import click
 from click_help_colors import HelpColorsCommand
 from rapyuta_io.utils.rest_client import HttpMethod
-from yaspin import kbi_safe_yaspin
+
+if sys.stdout.isatty():
+    from yaspin import kbi_safe_yaspin as Spinner
+else:
+    from riocli.utils.spinner import DummySpinner as Spinner
 
 from riocli.constants import Colors, Symbols
 from riocli.parameter.utils import _api_call
@@ -43,7 +49,7 @@ def delete_configurations(
     if not silent:
         click.confirm('Do you want to proceed?', default=True, abort=True)
 
-    with kbi_safe_yaspin(text='Deleting...', timer=True) as spinner:
+    with Spinner(text='Deleting...', timer=True) as spinner:
         try:
             data = _api_call(HttpMethod.DELETE, name=tree)
             if data.get('data') != 'ok':

--- a/riocli/parameter/upload.py
+++ b/riocli/parameter/upload.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import typing
 
 import click
 from click_help_colors import HelpColorsCommand
-from yaspin import kbi_safe_yaspin
 
+if sys.stdout.isatty():
+    from yaspin import kbi_safe_yaspin as Spinner
+else:
+    from riocli.utils.spinner import DummySpinner as Spinner
 from riocli.config import new_client
 from riocli.constants import Colors, Symbols
 from riocli.parameter.utils import filter_trees, display_trees
@@ -57,8 +61,7 @@ def upload_configurations(
 
     client = new_client()
 
-    with kbi_safe_yaspin(text="Uploading configurations...",
-                         timer=True) as spinner:
+    with Spinner(text="Uploading configurations...", timer=True) as spinner:
         try:
             client.upload_configurations(
                 rootdir=path,


### PR DESCRIPTION
## Description
The CLI integration tests execute the CLI commands via script that does not have a TTY stream. Yaspin isn't really pipesafe https://github.com/pavdmyt/yaspin/issues/31 and it scrambles the output received in the script.

This PR implements a dummy spinner class that replaces the yaspin spinner when the stream is not a TTY.

## Demo
[![asciicast](https://asciinema.org/a/600665.svg)](https://asciinema.org/a/600665)

## Testing
**Runs `rio secret delete` via script**
```
09:56:20 (rapyuta-io-cli-eJqwJnu2) pallab@pop-os rapyuta-io-cli ±|fix/disable-spinner-if-notty ✗|
→ python test.py 
✅ Secret deleted successfully.

```
**Runs `rio apply` via script**
```
09:59:02 (rapyuta-io-cli-eJqwJnu2) pallab@pop-os rapyuta-io-cli ±|fix/disable-spinner-if-notty ✗|
→ python test.py 
----- Files Processed ----
/home/pallab/workspace/playground/riocli-manifests/simple-all/secret.yaml
                       Resource Context
--------------------  ------------------
Expected Time (mins)         0.05
Files                         1
Resources                     1
                                                                                
Resource         Action     Expected Time (mins)
---------------  --------  ----------------------
secret:secret01  CREATE             0.05
                                                                                
>> ⏳ Create secret:secret01                   [2023-08-04T21:59:04.804954]
>> ✅ Created secret:secret01                  [2023-08-04T21:59:05.326364]
✅ Apply successful.

```
