### PR TITLE
🐛 fix(apply): returns exit code when apply command fails

### DIFF
--- a/riocli/apply/parse.py
+++ b/riocli/apply/parse.py
@@ -95,6 +95,7 @@ class Applier(object):
         except Exception as e:
             spinner.text = 'Apply failed. Error: {}'.format(e)
             spinner.red.fail(Symbols.ERROR)
+            raise SystemExit(1) from e
 
     def apply_async(self, *args, **kwargs):
         workers = int(kwargs.get('workers') or self.DEFAULT_MAX_WORKERS)


### PR DESCRIPTION
## Description
This PR fixes the apply command to return an exit code when it fails.

> Wrike: https://www.wrike.com/open.htm?id=1175574159