### PR TITLE
🐛 fix(update): removes the requirement of privileged access

### DIFF
--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -107,7 +107,7 @@ def update(silent: bool) -> None:
         else:
             update_appimage(version=latest)
     except Exception as e:
-        click.secho('{} Failed to update the CLI'.format(e), fg=Colors.RED)
+        click.secho('{} Failed to update: {}'.format(Symbols.ERROR, e), fg=Colors.RED)
         raise SystemExit(1) from e
 
     click.secho('{} Update successful!'.format(Symbols.SUCCESS),


### PR DESCRIPTION
### Description
This PR fixes the following issues with the `rio update` command
- requires privileged access to update the appimage even when the file is at a non-privileged location
- The file move fails with the error: `Invalid cross-device link: '/tmp/tmp354y0nsn/rio' -> '/home/ankit/.local/bin/rio'`

### Testing
```
01:43:02 pallab@pop-os appimages 
→ rio version
rio 0.6.0 / SDK 1.11.1

01:43:06 pallab@pop-os appimages 
→ rio update -f
🎉 A newer version (4.0.3) is available.
⚠️ Please consider running as a root user.
❌ Failed to update: [Errno 13] Permission denied: '/usr/local/bin/rio'

01:43:13 pallab@pop-os appimages 
→ doas rio update -f
🎉 A newer version (4.0.3) is available.
✅ Update successful!

01:43:26 pallab@pop-os appimages 
→ doas cp rio /usr/local/bin/

01:43:42 pallab@pop-os appimages 
→ sudo rio update -f
🎉 A newer version (4.0.3) is available.
✅ Update successful!

01:43:51 pallab@pop-os appimages 
→ rio version
rio 4.0.3 / SDK 1.11.1
```