### PR TITLE
fix(jsonschema): corrects property name in package livenessProbe definition

### DIFF
--- a/riocli/apply/manifests/package-nonros-device.yaml
+++ b/riocli/apply/manifests/package-nonros-device.yaml
@@ -41,7 +41,7 @@ spec:
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
       livenessProbe:
-        http:
+        httpGet:
           path: "/"
           port: 90
         initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.

--- a/riocli/apply/manifests/package-ros-device-no-rosbag.yaml
+++ b/riocli/apply/manifests/package-ros-device-no-rosbag.yaml
@@ -22,7 +22,7 @@ spec:
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
       livenessProbe: # Optional
-        tcp:
+        tcpSocket:
           port: 999
         initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
         periodSeconds: 10 # How often (in seconds) to perform the probe.
@@ -41,7 +41,7 @@ spec:
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
       livenessProbe: # Optional
-        http:
+        httpGet:
           path: "/"
           port: 90
         initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.

--- a/riocli/apply/manifests/package-ros-device-rosbag.yaml
+++ b/riocli/apply/manifests/package-ros-device-rosbag.yaml
@@ -22,7 +22,7 @@ spec:
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
       livenessProbe: # Optional
-        http:
+        httpGet:
           path: "/"
           port: 90
         initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.

--- a/riocli/apply/manifests/package.yaml
+++ b/riocli/apply/manifests/package.yaml
@@ -407,7 +407,7 @@ spec:
         depends:
           kind: build
           nameOrGUID: "build"
-    - name: "exec-docker"
+    - name: "exec-docker-01"
       type: docker # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"
       runAsBash: True
@@ -415,9 +415,8 @@ spec:
         cpu: 0.025 # Unit: Core (Optional)
         memory: 128 # Unit: MB (Optional)
       livenessProbe: # Optional
-        exec:
-          command:
-            - "shell-cmd"
+        tcpSocket:
+          port: 8080
         initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
         periodSeconds: 10 # How often (in seconds) to perform the probe.
         failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
@@ -430,6 +429,24 @@ spec:
           depends:
             kind: secret
             nameOrGUID: "secret-docker"
+    - name: "exec-docker-02"
+      type: docker # Options: [docker (default), build, preInstalled]
+      runAsBash: True
+      limits: # Optional
+        cpu: 0.025 # Unit: Core (Optional)
+        memory: 128 # Unit: MB (Optional)
+      livenessProbe: # Optional
+        httpGet:
+          path: "/"
+          port: 80
+        initialDelaySeconds: 5  # Number of seconds after the container has started before liveness probes are initiated.
+        periodSeconds: 10 # How often (in seconds) to perform the probe.
+        failureThreshold: 1 # Minimum consecutive failures for the probe to be considered failed after having succeeded.
+        successThreshold: 3 # Minimum consecutive successes for the probe to be considered successful after having failed.
+        timeoutSeconds: 1 # Number of seconds after which the probe times out.
+      docker:
+        image: "nginx:latest"
+        imagePullPolicy: "Always" # Always, Never, IfNotPresent(default)
     - name: "exec-preInstalled"
       type: preInstalled # Options: [docker (default), build, preInstalled]
       command: "roslaunch talker talker.launch"

--- a/riocli/jsonschema/schemas/package-schema.yaml
+++ b/riocli/jsonschema/schemas/package-schema.yaml
@@ -753,7 +753,7 @@ definitions:
           port:
             type: integer
             description: Port number for the HTTP probe.
-          schema:
+          scheme:
             type: string
             default: HTTP
             description: Scheme to use for connecting to the host.


### PR DESCRIPTION
### Description

The `httpGet` section of `livenessProbe` has a mistake that leads to an incorrect payload which lead of deployment failures.