### PR TITLE
🐛 fix: fixes static route dependencies during apply

### DIFF
--- a/riocli/apply/resolver.py
+++ b/riocli/apply/resolver.py
@@ -159,8 +159,8 @@ class ResolverCache(object, metaclass=_Singleton):
             "project": lambda name, projects: filter(lambda i: i.metadata.name == name, projects),
             "package": lambda name, obj_list, version: filter(
                 lambda x: name == x.name and version == x['packageVersion'], obj_list),
-            "staticroute": lambda name, obj_list: filter(lambda x: name == '-'.join(x.spec.url.split('-')[:-1]),
-                                                         obj_list),
+            "staticroute": lambda name, obj_list: filter(
+                lambda x: name == x.metadata.name.rsplit('-', 1)[0], obj_list),
             "build": self._generate_find_guid_functor(name_field='buildName'),
             "deployment": self._generate_find_guid_functor(),
             "network": self._generate_find_guid_functor(),

--- a/riocli/deployment/model.py
+++ b/riocli/deployment/model.py
@@ -17,6 +17,8 @@ import typing
 import click
 from rapyuta_io import Client
 from rapyuta_io.clients.catalog_client import Package
+from rapyuta_io.clients import ObjDict
+from rapyuta_io.clients.static_route import StaticRoute
 from rapyuta_io.clients.deployment import DeploymentNotRunningException, DeploymentPhaseConstants
 from rapyuta_io.clients.native_network import NativeNetwork
 from rapyuta_io.clients.package import ProvisionConfiguration, RestartPolicy, \
@@ -119,8 +121,8 @@ class Deployment(Model):
             if 'staticRoutes' in self.spec:
                 for stroute in self.spec.staticRoutes:
                     route_guid, route = self.rc.find_depends(stroute.depends)
-                    if route is None and route_guid:
-                        route = client.get_static_route(route_guid)
+                    # TODO: Remove this once we transition to v2
+                    route = StaticRoute(ObjDict({"guid": route_guid}))
                     provision_config.add_static_route(component_name,
                                                       stroute.name, route)
 

--- a/riocli/static_route/model.py
+++ b/riocli/static_route/model.py
@@ -50,7 +50,7 @@ class StaticRoute(Model):
 
     def delete_object(self, client: Client, obj: typing.Any):
         client = new_v2_client()
-        client.delete_static_route(obj.name)
+        client.delete_static_route(obj.metadata.name)
 
     @classmethod
     def pre_process(cls, client: Client, d: typing.Dict) -> None:


### PR DESCRIPTION
### Description

The `find_functor` for staticroute was not able to parse URLs of the kind `ims-coredev-axylr.ep-r.io`. The easier way is to simply parse the name instead and split on the first `-` from the right.

### Testing
```yaml
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: "StaticRoute"
metadata:
  name: "testnginx"
  labels:
    app: nginx
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: Package
metadata:
  name: "nginx"
  version: "1.0.0"
  labels:
    app: nginx
spec:
  runtime: cloud
  cloud:
    replicas: 1
  executables:
    - name: nginx
      type: docker
      docker:
        image: nginx
  endpoints:
    - name: "testnginx"
      type: external-http
      port: 80
      targetPort: 80
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: Deployment
metadata:
  name: "nginx-dep"
  depends:
    kind: package
    nameOrGUID: "nginx"
    version: "1.0.0"
spec:
  runtime: cloud
  staticRoutes:
    - name: "testnginx"
      depends:
        kind: staticroute
        nameOrGUID: "testnginx"
```
```
→ pipenv run python -m riocli apply ~/workspace/playground/riocli-manifests/static-route/deployment.yaml -f
----- Files Processed ----
/home/pallab/workspace/playground/riocli-manifests/static-route/deployment.yaml
                       Resource Context
--------------------  ------------------
Expected Time (mins)         4.1
Files                         1
Resources                     3
                                                                                                                                                                                                                                                      
Resource               Action     Expected Time (mins)
---------------------  --------  ----------------------
staticroute:testnginx  CREATE             0.05
package:nginx          CREATE             0.05
deployment:nginx-dep   CREATE              4
                                                                                                                                                                                                                                                      
>> ⏳ Create staticroute:testnginx                                                                                                                                                                                   [2023-09-22T11:48:50.848474]
>> ⏳ Create package:nginx                                                                                                                                                                                           [2023-09-22T11:48:51.299730]
>> ✅ Created staticroute:testnginx                                                                                                                                                                                  [2023-09-22T11:48:51.471175]
>> ✅ Created package:nginx                                                                                                                                                                                          [2023-09-22T11:48:52.004061]
>> ⏳ Create deployment:nginx-dep                                                                                                                                                                                    [2023-09-22T11:48:52.576758]
>> ✅ Created deployment:nginx-dep                                                                                                                                                                                   [2023-09-22T11:49:06.695185]
✅ Apply successful. (0:00:17.51)


→ pipenv run python -m riocli delete ~/workspace/playground/riocli-manifests/static-route/deployment.yaml -f
                       Resource Context
--------------------  ------------------
Expected Time (mins)         4.1
Files                         1
Resources                     3
                                                                                                                                                                                                                                                      
Resource               Action     Expected Time (mins)
---------------------  --------  ----------------------
staticroute:testnginx  DELETE             0.05
package:nginx          DELETE             0.05
deployment:nginx-dep   CREATE              4
                                                                                                                                                                                                                                                      
>> ⏳ Delete deployment:nginx-dep                                                                                                                                                                                    [2023-09-22T11:49:18.688110]
>> ✅ Deleted deployment:nginx-dep                                                                                                                                                                                   [2023-09-22T11:49:21.062005]
>> ⏳ Delete package:nginx                                                                                                                                                                                           [2023-09-22T11:49:23.334637]
>> ✅ Deleted package:nginx                                                                                                                                                                                          [2023-09-22T11:49:23.856992]
>> ⏳ Delete staticroute:testnginx                                                                                                                                                                                   [2023-09-22T11:49:25.508961]
>> ✅ Deleted staticroute:testnginx                                                                                                                                                                                  [2023-09-22T11:49:26.089168]
✅ Delete successful. (0:00:07.95)
```