### PR TITLE
🐛 fix(vpn): displays DNS name in vpn status

### DIFF
--- a/riocli/vpn/status.py
+++ b/riocli/vpn/status.py
@@ -79,7 +79,7 @@ def display_vpn_status(wide: bool = False):
     nodes = s.get('Peer', {})
     nodes.update({"me": s.get('Self')})
 
-    headers = ['IP', 'Host Name', 'OS', 'Online', 'Active']
+    headers = ['IP', 'DNS Name', 'OS', 'Online', 'Active']
 
     if wide:
         headers.extend(['Relay', 'Joined', 'Last Active'])
@@ -88,7 +88,8 @@ def display_vpn_status(wide: bool = False):
     for k, v in nodes.items():
         row = [
             ",".join(v.get('TailscaleIPs')),
-            v.get('HostName'),
+            # removesuffix() is available starting Python 3.9
+            v.get('DNSName', '').replace('.' + s.get('MagicDNSSuffix'), ''),
             v.get('OS'),
             v.get('Online'),
             v.get('Active'),


### PR DESCRIPTION
### Description

This PR fixes the `rio vpn status` command to show the DNS name of nodes instead of the host name registered with headscale. The DNS name is the one that is resolved by MagicDNS and not the host name and thus, it seems more intuitive to show the DNS name. The host name can be inferred from this name as well.

### Testing
```
→ pipenv run python -m riocli vpn status
ℹ️ VPN is enabled in the project (lgs-hmr-001)

IP           DNS Name                                               OS     Online    Active
-----------  -----------------------------------------------------  -----  --------  --------
100.64.0.12  edge01-kyjqi1iz                                        linux  True      False
100.64.0.1   subnet-router.rapyuta.rio.internal                     linux  True      False
100.64.0.14  inst-byrcmzqxgwwidqucldqgwfkg-lytxbh-7b76946cf9-ksdn7  linux  True      False
100.64.0.11  pop-os                                                 linux  True      False

DNS Suffix: rio-internal-headscale-project-hcoqufftmuvwamhuiydfidas.rio.internal

ℹ️ You are connected to the VPN.
```
```
→ ssh rr@edge01-kyjqi1iz
The authenticity of host 'edge01-kyjqi1iz (100.64.0.12)' can't be established.
ED25519 key fingerprint is SHA256:T7Mty+p2emncGYKOfzUU25TjwoyApxV8v0Pt+02PiK0.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'edge01-kyjqi1iz' (ED25519) to the list of known hosts.
rr@edge01-kyjqi1iz's password: 
rr@edge01:~$ exit
logout
Connection to edge01-kyjqi1iz closed.
```