### PR TITLE
fix(usergroup): fixes inspect when group has deleted projects

### DIFF
--- a/riocli/usergroup/inspect.py
+++ b/riocli/usergroup/inspect.py
@@ -55,7 +55,8 @@ def to_manifest(usergroup: UserGroup, org_guid: str) -> typing.Dict:
     role_map = {i['projectGUID']: i['groupRole'] for i in (usergroup.role_in_projects or [])}
     members = {m.email_id for m in usergroup.members}
     admins = {a.email_id for a in usergroup.admins}
-    projects = [{'name': p.name, 'role': role_map[p.guid]} for p in (usergroup.projects or [])]
+    projects = [{'name': p.name, 'role': role_map.get(p.guid)}
+                for p in (usergroup.projects or []) if p.guid in role_map]
 
     return {
         'apiVersion': 'api.rapyuta.io/v2',


### PR DESCRIPTION
### Description
There are cases when a project is deleted before being removed from the group. Since this is use case that we allow, in the recent v2 API changes, the delete project does not update the association tables. Hence, the `GET /api/groups/:id` call ends up getting the projects in the DB. But they don't have any role associated with them which breaks the inspect command.

This PR fixes that by handling such projects that do not have a corresponding role. However, the right way to do things would be to update the association tables corresponding a project.