### PR TITLE
🐛 fix(vpn): avoids sudo when running as root

### DIFF
--- a/riocli/vpn/connect.py
+++ b/riocli/vpn/connect.py
@@ -27,6 +27,7 @@ from riocli.utils import run_bash_with_return_code
 from riocli.utils.spinner import with_spinner
 from riocli.v2client import Client as v2Client
 from riocli.vpn.util import (
+    get_command,
     is_tailscale_up,
     stop_tailscale,
     install_vpn_tools,
@@ -107,13 +108,10 @@ def start_tailscale(
         client: v2Client,
         spinner: Yaspin,
 ) -> bool:
-    cmd = ('sudo tailscale up --auth-key={} --login-server={}'
-           ' --reset --force-reauth --accept-routes --accept-dns'
-           ' --advertise-tags={} --timeout=30s')
+    cmd = get_command('tailscale up --auth-key={} --login-server={} --reset --force-reauth '
+                      '--accept-routes --accept-dns --advertise-tags={} --timeout=30s')
     args = generate_tailscale_args(ctx, client, spinner)
-    command = cmd.format(args.HEADSCALE_PRE_AUTH_KEY,
-                         args.HEADSCALE_URL,
-                         args.HEADSCALE_ACL_TAG)
+    command = cmd.format(args.HEADSCALE_PRE_AUTH_KEY, args.HEADSCALE_URL, args.HEADSCALE_ACL_TAG)
     output, code = run_bash_with_return_code(command)
     if code != 0:
         spinner.write(


### PR DESCRIPTION
### Description
A few `tailscale` commands require root privilege to run and are executed with `sudo`. However, when the user is already the root user, the CLI throws an error. This PR fixes that by adding sudo only when the executing user is non-root.

![image](https://github.com/rapyuta-robotics/rapyuta-io-cli/assets/5305744/6008df72-7b4c-4b98-a71c-8ca9f330a426)
