### PR TITLE
🐛 fix: miscellaneous bug fixes

### DIFF
--- a/riocli/apply/resolver.py
+++ b/riocli/apply/resolver.py
@@ -75,7 +75,7 @@ class ResolverCache(object, metaclass=_Singleton):
         "managedservice": "^[a-zA-Z][a-zA-Z0-9_-]$"
     }
 
-    GUID_KEYS = ['guid', 'GUID', 'uuid', 'ID', 'Id', 'id']
+    GUID_KEYS = ['guid', 'GUID', 'deploymentId', 'uuid', 'ID', 'Id', 'id']
     NAME_KEYS = ['name', 'urlPrefix', 'buildName']
 
     def __init__(self, client):

--- a/riocli/device/delete.py
+++ b/riocli/device/delete.py
@@ -122,7 +122,7 @@ def delete_device(
         spinner.write('')
 
         if failed_count == 0 and success_count == len(devices):
-            spinner_text = click.style('All devices deleted successfully.', Colors.GREEN)
+            spinner_text = click.style('{} device(s) deleted successfully.'.format(len(devices)), Colors.GREEN)
             spinner_char = click.style(Symbols.SUCCESS, Colors.GREEN)
         elif success_count == 0 and failed_count == len(devices):
             spinner_text = click.style('Failed to delete devices', Colors.YELLOW)

--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -92,6 +92,7 @@ definitions:
         type: string
       subPath:
         type: string
+    additionalProperties: false
 
   endpointSpec:
     properties:

--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -144,7 +144,6 @@ definitions:
                   - always
                   - onfailure
                   - never
-                default: always
               envArgs:
                 type: array
                 items:

--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -90,9 +90,12 @@ definitions:
         type: string
       mountPath:
         type: string
+        pattern: '^([\\/][a-z0-9\s\-_@\-^!#$%&.]*)+(\.[a-z][a-z0-9]+)?$'
       subPath:
         type: string
+        pattern: '^([\\/][a-z0-9\s\-_@\-^!#$%&.]*)+(\.[a-z][a-z0-9]+)?$'
     additionalProperties: false
+
 
   endpointSpec:
     properties:

--- a/riocli/jsonschema/schemas/secret-schema.yaml
+++ b/riocli/jsonschema/schemas/secret-schema.yaml
@@ -25,6 +25,7 @@ definitions:
     properties:
       name:
         type: string
+        maxLength: 253
       guid:
         "$ref": "#/definitions/secretGUID"
       creator:

--- a/riocli/organization/select.py
+++ b/riocli/organization/select.py
@@ -62,8 +62,12 @@ def select_organization(
     if sys.stdout.isatty() and interactive:
         select_project(ctx.obj, organization=organization_guid)
     else:
+        ctx.obj.data['project_id'] = ""
+        ctx.obj.data['project_name'] = ""
         click.secho(
-            "Your organization has been set to '{}'".format(organization_name),
+            "Your organization has been set to '{}'\n"
+            "Please set your project with `rio project select PROJECT_NAME`".format(organization_name),
             fg=Colors.GREEN)
+
 
     ctx.obj.save()


### PR DESCRIPTION
Test manifests:

adds validation for applying cloud disk on device deployment
```
---
apiVersion: apiextensions.rapyuta.io/v1
kind: Package
metadata:
  description: Sootballs Printer Cups package
  labels:
    app: printer_cups
  name: sootballs_printer_cups
  version: 2.0.1-kokubu
spec:
  device:
    arch: amd64
    restart: always
  executables:
  - docker:
      image: nginx
    name: cups
    runAsBash: false
    type: docker
  runtime: device
#---
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  depends:
    kind: package
    nameOrGUID: pkg-oytmqdbzeajwyxsgczeawfzd
    version: 2.0.1-kokubu
  labels:
    app: printer_cups
  name: sootballs_printer_cups
spec:
  device:
    depends:
      kind: device
      nameOrGUID: romil-v3
  runtime: device
  volumes:
  - execName: cups
    mountPath: /etc/cups/printers.conf
    subPath: /opt/rapyuta/configs/cups/printers.conf
#    depends: #not for device
#      kind: disk
#      nameOrGUID: "romil"

```

test [Resolves misleading execution of command in wrong project in case of changing organization](https://www.wrike.com/open.htm?id=1230579582)
```
rio organization select Rapyuta2  --no-interactive
rio device create biswa --runtime dockercompose
```