### PR TITLE
fix(jsonschema): disallows additional properties for runtimes dependency

### DIFF
--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -116,6 +116,7 @@ definitions:
         "$ref": "#/definitions/managedServiceDepends"
 
   componentSpec:
+    type: object
     properties:
       runtime:
         type: string
@@ -183,6 +184,8 @@ definitions:
                         type: boolean
                     required:
                       - enabled
+            type: object
+            additionalProperties: false
 
           - properties:
               runtime:
@@ -242,6 +245,8 @@ definitions:
                 type: array
                 items:
                   "$ref": "#/definitions/cloudROSBagJobSpec"
+            type: object
+            additionalProperties: false
 
   cloudROSBagJobSpec:
     type: object

--- a/riocli/jsonschema/validate.py
+++ b/riocli/jsonschema/validate.py
@@ -25,6 +25,11 @@ def extend_with_default(validator_class):
         for p, sub_schema in properties.items():
             if "default" not in sub_schema:
                 continue
+
+            # Skip if property is not in instance
+            if p not in instance:
+                continue
+
             if isinstance(instance, dict):
                 instance.setdefault(p, sub_schema["default"])
             if isinstance(instance, list):

--- a/riocli/parameter/list.py
+++ b/riocli/parameter/list.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 import click
 from click_help_colors import HelpColorsCommand
-from rapyuta_io.utils.rest_client import HttpMethod
 
 from riocli.constants import Colors
-from riocli.parameter.utils import _api_call
+from riocli.parameter.utils import list_trees
 from riocli.utils import tabulate_data
 
 
@@ -31,14 +30,9 @@ def list_configuration_trees() -> None:
     List the Configuration Parameter Trees.
     """
     try:
-        data = _api_call(HttpMethod.GET)
-        if 'data' not in data:
-            raise Exception('Failed to list configurations')
-
-        trees = [[tree] for tree in data['data']]
-
+        data = list_trees()
+        trees = [[tree] for tree in data]
         tabulate_data(trees, headers=['Tree Name'])
-
     except Exception as e:
         click.secho(str(e), fg=Colors.RED)
         raise SystemExit(1)

--- a/riocli/parameter/utils.py
+++ b/riocli/parameter/utils.py
@@ -16,10 +16,12 @@ import json
 import os
 import typing
 from filecmp import dircmp
+from typing import List
 
 import click
 from directory_tree import display_tree
 from rapyuta_io.utils import RestClient
+from rapyuta_io.utils.rest_client import HttpMethod
 
 from riocli.config import Configuration
 from riocli.constants import Colors
@@ -78,6 +80,14 @@ def _api_call(
         err_msg = data.get('error')
         raise Exception(err_msg)
     return data
+
+
+def list_trees() -> List[str]:
+    resp = _api_call(HttpMethod.GET)
+    if 'data' not in resp:
+        raise Exception('Failed to list configurations')
+
+    return resp.get('data')
 
 
 class DeepDirCmp(dircmp):


### PR DESCRIPTION
### Description
This commit sets additionalProperties = false in case of the runtime dependency in deployments that allowed including unlisted attributes in the manifest. For example, including staticRoutes for device deployments is valid without the fix.

### Testing
Environment: io-dev
Organization: Rapyuta
Project: biswa

The following manifest is invalid and the apply command should throw and error.

```yaml
apiVersion: "apiextensions.rapyuta.io/v1"
kind: Package
metadata:
  name: "postgres"
  version: "1.0.0"
  labels:
    app: postgres
spec:
  runtime: device
  device:
    arch: amd64
    restart: always
  executables:
    - name: postgres
      type: docker
      docker:
        image: postgres:15.2
  environmentVars:
  - name: "POSTGRES_PASSWORD"
    default: "postgres"
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: Deployment
metadata:
  name: "postgres-device-01"
  depends:
    kind: package
    nameOrGUID: "postgres"
    version: "1.0.0"
spec:
  runtime: device
  device:
    depends:
      kind: device
      nameOrGUID: "docker-device"
  staticRoutes:
  - name: route01
    depends:
      kind: staticroute
      nameOrGUID: route01
  envArgs:
  - name: "POSTGRES_PASSWORD"
    value: "postgres"
```
```
→ pipenv run python -m riocli apply ~/workspace/playground/riocli-manifests/vpn/deployment.yaml --dryrun
----- Files Processed ----
/home/pallab/workspace/playground/riocli-manifests/vpn/deployment.yaml
                       Resource Context
--------------------  ------------------
Expected Time (mins)         4.18
Files                         1
Resources                     2
                                                                                                                                                                                                                                                      
Resource                       Action     Expected Time (mins)
-----------------------------  --------  ----------------------
package:postgres               CREATE             0.05
device:docker-device           UPDATE             0.08
staticroute:route01            UPDATE             0.05
deployment:postgres-device-01  CREATE              4
                                                                                                                                                                                                                                                      
>> ⏳ Create package:postgres                                                                                                                                                                                        [2024-01-18T23:58:10.935296]
[Err] Object "deployment:postgres-device-01" apply failed. Apply will not progress further.
❌ Apply failed. Error: {'runtime': 'device', 'device': {'depends': {'kind': 'device', 'nameOrGUID': 'docker-device', 'guid': '6b5438ed-ffe3-4855-9403-44cca58d2d1f'}}, 'staticRoutes': [{'name': 'route01', 'depends': {'kind': 'staticroute', 'nameOrGUID': 'route01', 'guid': 'staticroute-cmkmedsorrbs73fuub8g'}}], 'envArgs': [{'name': 'POSTGRES_PASSWORD', 'value': 'postgres'}], 'restart': 'always'} is not valid under any of the given schemas

```