### PR TITLE
 fix(jsonschema): makes runtime required in disks

### DIFF
--- a/riocli/disk/model.py
+++ b/riocli/disk/model.py
@@ -79,7 +79,7 @@ class Disk(Model):
         volume_instance = client.get_volume_instance(obj.internalDeploymentGUID)
         volume_instance.destroy_volume_instance()
 
-    def _poll_till_available(self, client: Client, obj: typing.Any, sleep_interval=5, retries=10):
+    def _poll_till_available(self, client: Client, obj: typing.Any, sleep_interval=5, retries=20):
         dep_guid = obj.internalDeploymentGUID
         deployment = client.get_deployment(deployment_id=dep_guid)
 

--- a/riocli/jsonschema/schemas/disk-schema.yaml
+++ b/riocli/jsonschema/schemas/disk-schema.yaml
@@ -56,8 +56,9 @@ definitions:
     type: object
     properties:
       runtime:
+        enum:
+          - cloud
         default: cloud
-        const: cloud
       capacity:
         type: number
         enum:

--- a/riocli/jsonschema/validate.py
+++ b/riocli/jsonschema/validate.py
@@ -25,11 +25,6 @@ def extend_with_default(validator_class):
         for p, sub_schema in properties.items():
             if "default" not in sub_schema:
                 continue
-
-            # Skip if property is not in instance
-            if p not in instance:
-                continue
-
             if isinstance(instance, dict):
                 instance.setdefault(p, sub_schema["default"])
             if isinstance(instance, list):


### PR DESCRIPTION
The runtime field hasn't been a mandatory field in the disks jsonschema. This commit corrects that by making them mandatory and it removes the default making the requirement an explicit one.