### PR TITLE
🐛 fix: miscellaneous bugs

### DIFF
--- a/riocli/deployment/delete.py
+++ b/riocli/deployment/delete.py
@@ -68,9 +68,9 @@ def delete_deployment(
         raise SystemExit(1) from e
 
     if not deployments:
-        spinner.text = "Nothing to delete"
-        spinner.ok(Symbols.SUCCESS)
-        return
+        spinner.text = click.style("Deployment(s) not found", Colors.RED)
+        spinner.red.fail(Symbols.ERROR)
+        raise SystemExit(1)
 
     with spinner.hidden():
         print_deployments_for_confirmation(deployments)

--- a/riocli/device/delete.py
+++ b/riocli/device/delete.py
@@ -69,9 +69,9 @@ def delete_device(
         raise SystemExit(1) from e
 
     if not devices:
-        spinner.text = "No devices to delete"
-        spinner.ok(Symbols.SUCCESS)
-        return
+        spinner.text = click.style("Device(s) not found", Colors.RED)
+        spinner.red.fail(Symbols.ERROR)
+        raise SystemExit(1)
 
     headers = ['Name', 'Device ID', 'Status']
     data = [[d.name, d.uuid, d.status] for d in devices]

--- a/riocli/package/delete.py
+++ b/riocli/package/delete.py
@@ -62,9 +62,9 @@ def delete_package(
         raise SystemExit(1) from e
 
     if not packages:
-        spinner.text = "Nothing to delete"
-        spinner.green.ok(Symbols.SUCCESS)
-        return
+        spinner.text = click.style("Package(s) not found", Colors.RED)
+        spinner.red.fail(Symbols.ERROR)
+        raise SystemExit(1)
 
     with spinner.hidden():
         print_packages_for_confirmation(packages)


### PR DESCRIPTION
### Description

This PR corrects the commands that do not return a non-zero exit code when a resource is not found during delete. The commands are
- `rio device delete`
- `rio package delete`
- `rio deployment delete`