### PR TITLE
fix: updates default service urls in api calls

### DIFF
--- a/riocli/apply/resolver.py
+++ b/riocli/apply/resolver.py
@@ -185,7 +185,7 @@ class ResolverCache(object, metaclass=_Singleton):
     def _list_disks(self):
         config = Configuration()
         catalog_host = config.data.get(
-            'catalog_host', 'https://gacatalog.apps.rapyuta.io')
+            'catalog_host', 'https://gacatalog.apps.okd4v2.prod.rapyuta.io')
         url = '{}/disk'.format(catalog_host)
         headers = config.get_auth_header()
         response = RestClient(url).method(

--- a/riocli/deployment/logs.py
+++ b/riocli/deployment/logs.py
@@ -67,5 +67,5 @@ def stream_deployment_logs(deployment_id, component_id, exec_id, pod_name=None):
 
 
 def get_log_stream_url(config, deployment_id, component_id, exec_id, pod_name=None, tail=50000):
-    catalog_host = config.data.get('catalog_host', 'https://gacatalog.apps.rapyuta.io')
+    catalog_host = config.data.get('catalog_host', 'https://gacatalog.apps.okd4v2.prod.rapyuta.io')
     return _LOG_URL_FORMAT.format(catalog_host, tail, deployment_id, component_id, exec_id, pod_name)

--- a/riocli/disk/util.py
+++ b/riocli/disk/util.py
@@ -38,7 +38,7 @@ def _api_call(
 ) -> typing.Any:
     config = Configuration()
     catalog_host = config.data.get(
-        'catalog_host', 'https://gacatalog.apps.rapyuta.io')
+        'catalog_host', 'https://gacatalog.apps.okd4v2.prod.rapyuta.io')
 
     url = '{}/disk'.format(catalog_host)
     if guid:

--- a/riocli/organization/utils.py
+++ b/riocli/organization/utils.py
@@ -28,7 +28,7 @@ def _api_call(
     config = Configuration()
     coreapi_host = config.data.get(
         'core_api_host',
-        'https://gaapiserver.apps.rapyuta.io'
+        'https://gaapiserver.apps.okd4v2.prod.rapyuta.io'
     )
 
     url = '{}/api/organization'.format(coreapi_host)

--- a/riocli/parameter/utils.py
+++ b/riocli/parameter/utils.py
@@ -68,7 +68,7 @@ def _api_call(
 ) -> typing.Any:
     config = Configuration()
     catalog_host = config.data.get(
-        'core_api_host', 'https://gaapiserver.apps.rapyuta.io')
+        'core_api_host', 'https://gaapiserver.apps.okd4v2.prod.rapyuta.io')
     url = '{}/api/paramserver/tree'.format(catalog_host)
     if name:
         url = '{}/{}'.format(url, name)

--- a/riocli/utils/execute.py
+++ b/riocli/utils/execute.py
@@ -52,7 +52,7 @@ def _run_cloud_data(comp_id: str, exec_id: str, pod_name: str, command: typing.L
 
 
 def _run_cloud_url(config: Configuration, deployment_guid: str) -> str:
-    host = config.data.get('catalog_host', 'https://gacatalog.apps.rapyuta.io')
+    host = config.data.get('catalog_host', 'https://gacatalog.apps.okd4v2.prod.rapyuta.io')
     return _CLOUD_RUN_REMOTE_COMMAND.format(host, deployment_guid)
 
 


### PR DESCRIPTION
### Description

Fixes the issue where the `.apps.rapyuta.io` routes were used as default in some API calls that started failing after migrating to AKS. This PR fixes the issue by updating the default routes.