### PR TITLE
fix(jsonschema): corrects deployment component spec

### DIFF
--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -123,10 +123,6 @@ definitions:
         enum:
           - device
           - cloud
-      depends:
-        type: array
-        items:
-          "$ref": "#/definitions/deploymentDepends"
     dependencies:
       runtime:
         oneOf:
@@ -135,6 +131,10 @@ definitions:
                 type: string
                 enum:
                   - device
+              depends:
+                type: array
+                items:
+                  "$ref": "#/definitions/deploymentDepends"
               device:
                 type: object
                 properties:
@@ -151,22 +151,18 @@ definitions:
                 type: array
                 items:
                   "$ref": "#/definitions/envArgsSpec"
-
               volumes:
                 type: array
                 items:
                   "$ref": "#/definitions/deviceVolumeAttachSpec"
-
               rosNetworks:
                 type: array
                 items:
                   "$ref": "#/definitions/deviceNetworkAttachSpec"
-
               rosBagJobs:
                 type: array
                 items:
                   "$ref": "#/definitions/deviceROSBagJobSpec"
-
               features:
                 type: object
                 properties:
@@ -191,7 +187,10 @@ definitions:
                 type: string
                 enum:
                   - cloud
-
+              depends:
+                type: array
+                items:
+                  "$ref": "#/definitions/deploymentDepends"
               features:
                 type: object
                 properties:
@@ -219,27 +218,22 @@ definitions:
                 type: array
                 items:
                   "$ref": "#/definitions/envArgsSpec"
-
               volumes:
                 type: array
                 items:
                   "$ref": "#/definitions/cloudVolumeAttachSpec"
-
               staticRoutes:
                 type: array
                 items:
                   "$ref": "#/definitions/endpointSpec"
-
               rosNetworks:
                 type: array
                 items:
                   "$ref": "#/definitions/cloudNetworkAttachSpec"
-
               managedServices:
                 type: array
                 items:
                   "$ref": "#/definitions/managedServiceSpec"
-
               rosBagJobs:
                 type: array
                 items:


### PR DESCRIPTION
### Description
The depends attribute of the deployment schema is defined under the componentSpec which violates the additionalProperties=False setting of the dependencies for each runtime. This commit correct that by explicitly adding the depends section for each runtime.

_**The spec.**_
```yaml
spec:
  runtime: device
  device:
    depends:
      kind: device
      nameOrGUID: "{{ device.edge.name }}"
  depends:
    - kind: deployment
      nameOrGUID: oks_server
```
**_The error._**
```
>> :white_tick: Updated deployment:oks_web_interface                                                                                                [2024-02-01T12:23:19.016449]
:x: Apply failed. Error: {'runtime': 'device', 'device': {'depends': {'kind': 'device', 'nameOrGUID': 'edge01', 'guid': '3d6e8b0f-d3f1-4750-898e-253eb08e414e'}}, 'depends': [{'kind': 'deployment', 'nameOrGUID': 'oks_db', 'guid': 'dep-hgvpzjvinzialeseondtqkrf'}]} is not valid under any of the given schemas
```