### PR TITLE
🐛 fix: corrects the condition to fetch various resources

### DIFF
--- a/riocli/deployment/util.py
+++ b/riocli/deployment/util.py
@@ -171,9 +171,10 @@ def fetch_deployments(
                 DeploymentPhaseConstants.PROVISIONING])
     result = []
     for deployment in deployments:
-        if (include_all or
+        if (include_all or deployment_name_or_regex == deployment.name or
                 deployment_name_or_regex == deployment.deploymentId or
-                re.search(deployment_name_or_regex, deployment.name)):
+                (deployment_name_or_regex not in deployment.name and
+                 re.search(deployment_name_or_regex, deployment.name))):
             result.append(deployment)
 
     return result

--- a/riocli/device/util.py
+++ b/riocli/device/util.py
@@ -112,8 +112,10 @@ def fetch_devices(
     devices = client.get_all_devices(online_device=online_devices)
     result = []
     for device in devices:
-        if (include_all or device_name_or_regex == device.uuid or
-                re.search(device_name_or_regex, device.name)):
+        if (include_all or device.name == device_name_or_regex or
+                device_name_or_regex == device.uuid or
+                (device_name_or_regex not in device.name and
+                 re.search(device_name_or_regex, device.name))):
             result.append(device)
 
     return result

--- a/riocli/package/util.py
+++ b/riocli/package/util.py
@@ -91,7 +91,10 @@ def fetch_packages(
         if 'io-public' in pkg.packageId:
             continue
 
-        if include_all or re.search(package_name_or_regex, pkg.packageName):
+        if (include_all or package_name_or_regex == pkg.packageName or
+                pkg.packageId == package_name_or_regex or
+                (package_name_or_regex not in pkg.packageName and
+                 re.search(package_name_or_regex, pkg.packageName))):
             result.append(pkg)
 
     return result


### PR DESCRIPTION
### Description

This PR fixes the logic to fetch packages, devices and deployments based on a name, uuid and pattern. Release v7.0.0 has a bug that assumes all names to be patterns. For example, look at the following output
```
→ rio device list
Device ID                             Name          Status
------------------------------------  ------------  ----------
e93aaabf-0521-421a-bbb6-7249321e91c5  amit-testing  ONLINE
496c6c55-094f-4284-be01-5d9ca283d1c7  biswa1        ONLINE
005e3b19-929b-40ec-9230-6c624fc342c6  pallab        REGISTERED
f62a18a8-27c6-4b30-8463-93fb089a412d  pallab01      REGISTERED
6bddf8ff-dd85-4236-94e1-ee84fdc8959c  pallab011     REGISTERED
 
→ rio device delete pallab
Name       Device ID                             Status
---------  ------------------------------------  ----------
pallab011  6bddf8ff-dd85-4236-94e1-ee84fdc8959c  REGISTERED
pallab01   f62a18a8-27c6-4b30-8463-93fb089a412d  REGISTERED
pallab     005e3b19-929b-40ec-9230-6c624fc342c6  REGISTERED

Do you want to delete above device(s)? [Y/n]: n
Aborted!
```

This PR fixes that. Please look at the 

```
→ pipenv run python -m riocli device delete pallab
Name    Device ID                             Status
------  ------------------------------------  ----------
pallab  005e3b19-929b-40ec-9230-6c624fc342c6  REGISTERED

Do you want to delete above device(s)? [Y/n]: n
Aborted!

→ pipenv run python -m riocli device delete pallab*
Name       Device ID                             Status
---------  ------------------------------------  ----------
pallab011  6bddf8ff-dd85-4236-94e1-ee84fdc8959c  REGISTERED
pallab01   f62a18a8-27c6-4b30-8463-93fb089a412d  REGISTERED
pallab     005e3b19-929b-40ec-9230-6c624fc342c6  REGISTERED

Do you want to delete above device(s)? [Y/n]: n
Aborted!

```