### PR TITLE
🐛 fix(apply): raises error when a metadata has no name

### DIFF
--- a/riocli/apply/parse.py
+++ b/riocli/apply/parse.py
@@ -450,6 +450,9 @@ class Applier(object):
     @staticmethod
     def _get_object_key(obj: dict) -> str:
         kind = obj.get('kind').lower()
-        name_or_guid = obj['metadata']['name']
+        name_or_guid = obj.get('metadata', {}).get('name')
+
+        if not name_or_guid:
+            raise ValueError('[kind:{}] name is required.'.format(kind))
 
         return '{}:{}'.format(kind, name_or_guid)


### PR DESCRIPTION
### Description
When a resource manifest has no name in metadata, it throws a KeyError. This commit fixes the error reporting to state the issue more explicitly.