### PR TITLE
fix(jsonschema): corrects the regex for device volume paths

### DIFF
--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -90,10 +90,10 @@ definitions:
         type: string
       mountPath:
         type: string
-        pattern: '^([\\/][a-z0-9\s\-_@\-^!#$%&.]*)+(\.[a-z][a-z0-9]+)?$'
+        pattern: '^\/$|(^(?=\/)|^\.|^\.\.)(\/(?=[^/\0])[^/\0]+)*\/?$'
       subPath:
         type: string
-        pattern: '^([\\/][a-z0-9\s\-_@\-^!#$%&.]*)+(\.[a-z][a-z0-9]+)?$'
+        pattern: '^\/$|(^(?=\/)|^\.|^\.\.)(\/(?=[^/\0])[^/\0]+)*\/?$'
     additionalProperties: false
 
 


### PR DESCRIPTION
### Description
The regex for device volume mount and subpath does not account for files and only accepts directories. However, this is not the expectation as we can mount either files or directories. This commit corrects the regex.

Referring a regex found here: https://regex101.com/r/wal8VG/33

Wrike Ticket: https://www.wrike.com/open.htm?id=1295041413

### Testing
#### Manifest
```yaml
apiVersion: apiextensions.rapyuta.io/v1
kind: Deployment
metadata:
  name: gateway
  depends:
    kind: package
    nameOrGUID: gateway
    version: "1.0.0"
spec:
  runtime: device
  device:
    depends:
      kind: device
      nameOrGUID: "{{ device.edge.name }}"
  volumes:
    - execName: "gateway"
      mountPath: "/etc/caddy/config.json"
      subPath: "/opt/rapyuta/configs/gateway/config.json"
    - execName: "gateway"
      mountPath: "/etc/caddy/Caddyfile"
      subPath: "/opt/rapyuta/configs/gateway/preseed.yaml"
  features:
    params:
      enabled: true
      trees:
        - gateway
```

#### Error
```
→ rio apply templates/server/gateway.yaml -v values.sample.yaml --dryrun
----- Files Processed ----
/home/pallab/workspace/go/src/github.com/rapyuta-robotics/rr_oks_deploy/templates/server/gateway.yaml
                       Resource Context
--------------------  ------------------
Expected Time (mins)         4.13
Files                         1
Resources                     2
                                                                                                                                                                                                             
Resource            Action     Expected Time (mins)
------------------  --------  ----------------------
package:gateway     CREATE             0.05
device:edge01       UPDATE             0.08
deployment:gateway  CREATE              4
                                                                                                                                                                                                             
>> ⏳ Create package:gateway                                                                                                                                                [2024-02-04T12:33:06.055096]
[Err] Object "deployment:gateway" apply failed. Apply will not progress further.
❌ Apply failed. Error: {'runtime': 'device', 'device': {'depends': {'kind': 'device', 'nameOrGUID': 'edge01', 'guid': '6fad178d-fbe8-4cde-add5-64ef63dbe8d1'}}, 'volumes': [{'execName': 'gateway', 'mountPath': '/etc/caddy/config.json', 'subPath': '/opt/rapyuta/configs/gateway/config.json'}, {'execName': 'gateway', 'mountPath': '/etc/caddy/Caddyfile', 'subPath': '/opt/rapyuta/configs/gateway/preseed.yaml'}], 'features': {'params': {'enabled': True, 'trees': ['gateway']}}} is not valid under any of the given schemas
```

#### Fix
```
→ pipenv run python -m riocli apply ~/workspace/go/src/github.com/rapyuta-robotics/rr_oks_deploy/templates/server/gateway.yaml -v ~/workspace/go/src/github.com/rapyuta-robotics/rr_oks_deploy/values.sample.yaml --dryrun
----- Files Processed ----
/home/pallab/workspace/go/src/github.com/rapyuta-robotics/rr_oks_deploy/templates/server/gateway.yaml
                       Resource Context
--------------------  ------------------
Expected Time (mins)         4.13
Files                         1
Resources                     2
                                                                                                                                                                                                                                                      
Resource            Action     Expected Time (mins)
------------------  --------  ----------------------
package:gateway     CREATE             0.05
device:edge01       UPDATE             0.08
deployment:gateway  CREATE              4
                                                                                                                                                                                                                                                      
>> ⏳ Create package:gateway                                                                                                                                                                                         [2024-02-04T12:33:44.907066]
>> ⏳ Create deployment:gateway                                                                                                                                                                                      [2024-02-04T12:33:45.538051]
✅ Apply successful. (0:00:01.59)
```