### PR TITLE
fix(v2client): updates limits for list secrets and routes

### DIFF
--- a/riocli/v2client/client.py
+++ b/riocli/v2client/client.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -342,7 +342,7 @@ class Client(metaclass=Singleton):
         while True:
             params.update({
                 "continue": offset,
-                "limit": 10,
+                "limit": 50,
             })
             response = RestClient(url).method(HttpMethod.GET).query_param(
                 params).headers(headers).execute()
@@ -463,7 +463,7 @@ class Client(metaclass=Singleton):
         while True:
             params.update({
                 "continue": offset,
-                "limit": 10,
+                "limit": 50,
             })
             response = RestClient(url).method(HttpMethod.GET).query_param(
                 params).headers(headers).execute()


### PR DESCRIPTION
### Description
The existing limits for list secrets and static routes were set to 10 which is quite low. This leads to an increased number of calls to the apiserver. This commit increases the limit to 50, reducing the calls required to fetch all the items.