### PR TITLE
🐛 fix: resolves issues around regex based ops

### DIFF
--- a/riocli/deployment/delete.py
+++ b/riocli/deployment/delete.py
@@ -79,8 +79,7 @@ def delete_deployment(
 
     if not force:
         with spinner.hidden():
-            click.confirm('Do you want to delete the above deployment(s)?',
-                          default=True, abort=True)
+            click.confirm('Do you want to delete the above deployment(s)?', abort=True)
         spinner.write('')
 
     try:

--- a/riocli/deployment/update.py
+++ b/riocli/deployment/update.py
@@ -82,8 +82,7 @@ def update_deployment(
 
     if not force:
         with spinner.hidden():
-            click.confirm('Do you want to update above deployment(s)?',
-                          default=True, abort=True)
+            click.confirm('Do you want to update above deployment(s)?', abort=True)
         spinner.write('')
 
     try:

--- a/riocli/deployment/util.py
+++ b/riocli/deployment/util.py
@@ -174,7 +174,7 @@ def fetch_deployments(
         if (include_all or deployment_name_or_regex == deployment.name or
                 deployment_name_or_regex == deployment.deploymentId or
                 (deployment_name_or_regex not in deployment.name and
-                 re.search(deployment_name_or_regex, deployment.name))):
+                 re.search(r'^{}$'.format(deployment_name_or_regex), deployment.name))):
             result.append(deployment)
 
     return result

--- a/riocli/device/delete.py
+++ b/riocli/device/delete.py
@@ -83,8 +83,7 @@ def delete_device(
 
     if not force:
         with spinner.hidden():
-            click.confirm('Do you want to delete above device(s)?',
-                          default=True, abort=True)
+            click.confirm('Do you want to delete above device(s)?', abort=True)
         spinner.write('')
 
     try:

--- a/riocli/device/util.py
+++ b/riocli/device/util.py
@@ -115,7 +115,7 @@ def fetch_devices(
         if (include_all or device.name == device_name_or_regex or
                 device_name_or_regex == device.uuid or
                 (device_name_or_regex not in device.name and
-                 re.search(device_name_or_regex, device.name))):
+                 re.search(r'^{}$'.format(device_name_or_regex), device.name))):
             result.append(device)
 
     return result

--- a/riocli/package/util.py
+++ b/riocli/package/util.py
@@ -94,7 +94,7 @@ def fetch_packages(
         if (include_all or package_name_or_regex == pkg.packageName or
                 pkg.packageId == package_name_or_regex or
                 (package_name_or_regex not in pkg.packageName and
-                 re.search(package_name_or_regex, pkg.packageName))):
+                 re.search(r'^{}$'.format(package_name_or_regex), pkg.packageName))):
             result.append(pkg)
 
     return result


### PR DESCRIPTION
### Description
This PR resolves the following tickets:
* https://www.wrike.com/open.htm?id=1300147027
* https://www.wrike.com/open.htm?id=1300152105
* https://www.wrike.com/open.htm?id=1300152784
* https://www.wrike.com/open.htm?id=1299310557
* https://www.wrike.com/open.htm?id=1299312443

**Reported By:** @biswakalyansahoo 

### Testing
```
→ pipenv run python -m riocli device list
Device ID                             Name                  Status
------------------------------------  --------------------  ----------
1007d68b-7912-43da-8091-fd947bc52da8  amr01                 REGISTERED
3736bc21-84ea-4a7d-82ad-8acc5a2b2151  amr01_robotui         REGISTERED
23f20e03-bfd3-4746-9a92-ddbb82c64972  etcd_amr01            REGISTERED
51b0dc70-27bd-47c2-b640-ed8f50b7881e  otel-collector-amr01  REGISTERED

→ pipenv run python -m riocli device delete amr01
Name    Device ID                             Status
------  ------------------------------------  ----------
amr01   1007d68b-7912-43da-8091-fd947bc52da8  REGISTERED

Do you want to delete above device(s)? [y/N]: 
Aborted!

→ pipenv run python -m riocli device delete amr01.*
Name           Device ID                             Status
-------------  ------------------------------------  ----------
amr01          1007d68b-7912-43da-8091-fd947bc52da8  REGISTERED
amr01_robotui  3736bc21-84ea-4a7d-82ad-8acc5a2b2151  REGISTERED

Do you want to delete above device(s)? [y/N]: 
Aborted!

→ pipenv run python -m riocli device delete .*amr01.*
Name                  Device ID                             Status
--------------------  ------------------------------------  ----------
amr01                 1007d68b-7912-43da-8091-fd947bc52da8  REGISTERED
etcd_amr01            23f20e03-bfd3-4746-9a92-ddbb82c64972  REGISTERED
amr01_robotui         3736bc21-84ea-4a7d-82ad-8acc5a2b2151  REGISTERED
otel-collector-amr01  51b0dc70-27bd-47c2-b640-ed8f50b7881e  REGISTERED

Do you want to delete above device(s)? [y/N]: 
Aborted!
```