### PR TITLE
fix: sets default confirmation action to 'No'

### DIFF
--- a/riocli/deployment/delete.py
+++ b/riocli/deployment/delete.py
@@ -79,8 +79,7 @@ def delete_deployment(
 
     if not force:
         with spinner.hidden():
-            click.confirm('Do you want to delete the above deployment(s)?',
-                          default=True, abort=True)
+            click.confirm('Do you want to delete the above deployment(s)?', abort=True)
         spinner.write('')
 
     try:

--- a/riocli/deployment/update.py
+++ b/riocli/deployment/update.py
@@ -82,8 +82,7 @@ def update_deployment(
 
     if not force:
         with spinner.hidden():
-            click.confirm('Do you want to update above deployment(s)?',
-                          default=True, abort=True)
+            click.confirm('Do you want to update above deployment(s)?', abort=True)
         spinner.write('')
 
     try:

--- a/riocli/device/delete.py
+++ b/riocli/device/delete.py
@@ -83,8 +83,7 @@ def delete_device(
 
     if not force:
         with spinner.hidden():
-            click.confirm('Do you want to delete above device(s)?',
-                          default=True, abort=True)
+            click.confirm('Do you want to delete above device(s)?', abort=True)
         spinner.write('')
 
     try:


### PR DESCRIPTION
Certain confirmations had the default action set to True. This would mean that if someone hits the return key, then it will go ahead and perform the action. It may lead to unwanted consequences and thus a risky option to have in the CLI. This commit fixes that.

Wrike Ticket: https://www.wrike.com/open.htm?id=1299312443