### PR TITLE
feat(project): implements whoami command

### DIFF
--- a/riocli/config/config.py
+++ b/riocli/config/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@ import errno
 import json
 import os
 import uuid
+from functools import lru_cache
 
 from click import get_app_dir
 from rapyuta_io import Client
@@ -64,6 +65,11 @@ class Configuration(object):
         with open(self.filepath, 'w') as config_file:
             json.dump(self.data, config_file)
 
+    # We are using lru_cache to cache the calls to new_v2_client
+    # with project and without project. This is to avoid creating a
+    # new client object every time we call new_v2_client.
+    # https://docs.python.org/3.8/library/functools.html#functools.lru_cache
+    @lru_cache(maxsize=2)
     def new_client(self, with_project: bool = True) -> Client:
         if 'auth_token' not in self.data:
             raise LoggedOut
@@ -81,6 +87,7 @@ class Configuration(object):
 
         return Client(auth_token=token, project=project)
 
+    @lru_cache(maxsize=2)
     def new_v2_client(self, with_project: bool = True) -> v2Client:
         if 'auth_token' not in self.data:
             raise LoggedOut

--- a/riocli/project/__init__.py
+++ b/riocli/project/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ from riocli.project.features import features
 from riocli.project.inspect import inspect_project
 from riocli.project.list import list_project
 from riocli.project.select import select_project
+from riocli.project.whoami import whoami
 
 
 @click.group(
@@ -41,3 +42,4 @@ project.add_command(delete_project)
 project.add_command(select_project)
 project.add_command(inspect_project)
 project.add_command(features)
+project.add_command(whoami)

--- a/riocli/project/whoami.py
+++ b/riocli/project/whoami.py
@@ -1,0 +1,111 @@
+# Copyright 2024 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import click
+from click_help_colors import HelpColorsCommand
+
+from riocli.config import Configuration
+from riocli.constants import Colors
+from riocli.exceptions import LoggedOut
+from riocli.project.util import name_to_guid
+
+ADMIN_ROLE = 'admin'
+
+
+@click.command(
+    'whoami',
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+@click.option('-p', '--project-name', type=str)
+@name_to_guid
+@click.pass_context
+def whoami(ctx: click.Context, project_name: str, project_guid: str) -> None:
+    """
+    Find the role of the current user in a project.
+    """
+    if not ctx.obj.data.get('email_id'):
+        raise LoggedOut
+
+    try:
+        role = find_role(ctx.obj, project_guid)
+        click.echo(role)
+    except SystemExit as e:
+        click.secho(str(e), fg=Colors.RED)
+        raise SystemExit(1) from e
+
+
+def find_role(
+        config: Configuration,
+        project_guid: str = None,
+) -> str:
+    """
+    Find the role of the user in the project.
+
+    :param config: Configuration object
+    :param project_guid: GUID of the project
+
+    :return: Role of the user in the project
+    :raises: SystemExit
+    """
+    v1_client = config.new_client()
+    v2_client = config.new_v2_client()
+
+    # The user email comes from the config
+    user_email = config.data.get('email_id')
+    if not user_email:
+        raise ValueError('User email cannot be found in the config.')
+
+    # Default to the config values if not provided
+    if not project_guid:
+        project_guid = config.data.get('project_id')
+
+    if not project_guid:
+        raise ValueError('Project GUID cannot be found.')
+
+    try:
+        project = v2_client.get_project(project_guid)
+    except Exception as e:
+        raise e
+
+    role = None
+
+    # If user is present in the users list, check if they are and admin
+    for user in project.spec.get('users', []):
+        if user['emailID'] == user_email:
+            role = user['role']
+            break
+
+    if role and role == ADMIN_ROLE:
+        return role
+
+    # Else, the membership may be via a group. Lookup the groups the user
+    # has access to and compare them with the list of groups where the project
+    # is included.
+    try:
+        user_groups = v1_client.list_usergroups(project.metadata.get('organizationGUID'))
+        user_groups = {g.name: True for g in user_groups}
+    except Exception as e:
+        raise e
+
+    for group in project.spec.get('userGroups', []):
+        if group['name'] in user_groups:
+            if (not role) or (role != ADMIN_ROLE and group['role'] == ADMIN_ROLE):
+                role = group['role']
+                break
+
+    if not role:
+        raise Exception('User does not have access to the project')
+
+    return role

--- a/riocli/v2client/client.py
+++ b/riocli/v2client/client.py
@@ -19,6 +19,7 @@ import requests
 from munch import munchify, Munch
 from rapyuta_io.utils.rest_client import HttpMethod, RestClient
 
+
 def handle_server_errors(response: requests.Response):
     status_code = response.status_code
     # 500 Internal Server Error
@@ -67,17 +68,16 @@ class Client(object):
         """
         List all projects in an organization
         """
-        organization_guid = organization_guid or self._config.data.get(
-            'organization_id')
-        if not organization_guid:
-            raise Exception("projects: organization cannot be empty")
 
         url = "{}/v2/projects/".format(self._host)
         headers = {"Authorization": self._get_auth_token()}
 
-        params = {
-            "organizations": organization_guid,
-        }
+        params = {}
+
+        if organization_guid:
+            params.update({
+                "organizations": organization_guid,
+            })
 
         params.update(query or {})
 

--- a/riocli/v2client/client.py
+++ b/riocli/v2client/client.py
@@ -19,9 +19,6 @@ import requests
 from munch import munchify, Munch
 from rapyuta_io.utils.rest_client import HttpMethod, RestClient
 
-from riocli.utils import Singleton
-
-
 def handle_server_errors(response: requests.Response):
     status_code = response.status_code
     # 500 Internal Server Error
@@ -44,7 +41,7 @@ def handle_server_errors(response: requests.Response):
         raise Exception('unknown server error')
 
 
-class Client(metaclass=Singleton):
+class Client(object):
     """
     v2 API Client
     """


### PR DESCRIPTION
### Description
This commit introduces a new command that will help determine if a user has admin access in a certain project. It will print 'Yes' if the current context's user has 'admin' role in a given project. Else, it will print 'No'.

Wrike Ticket: https://www.wrike.com/open.htm?id=1291068805

### Usage
```
→ pipenv run python -m riocli project --help
Usage: python -m riocli project [OPTIONS] COMMAND [ARGS]...

  High-level groups for other resources

Options:
  --help  Show this message and exit.

Commands:
  create    Creates a new project
  delete    Deletes a project
  features  Toggle features on a project
  inspect   Inspect the project resource
  list      List all the projects you are part of
  select    Sets the given project in the CLI context.
  whoami    What is the role of the current user in the PROJECT?

→ pipenv run python -m riocli project whoami --help
Usage: python -m riocli project whoami [OPTIONS]

  What is the role of the current user in the PROJECT?

Options:
  -p, --project-name TEXT
  --help                   Show this message and exit.

```

### Testing
```
→ pipenv run python -m riocli project whoami -p hirano-1f
admin

→ pipenv run python -m riocli project whoami
admin

→ pipenv run python -m riocli project whoami hirano-3f
project not found
```

### Using `find_role` function in scripts
```
>>> from riocli.config import Configuration
>>> from riocli.project.whoami import find_role
>>> config = Configuration()
>>> find_role(config)
'admin'
>>> help(find_role)
Help on function find_role in module riocli.project.whoami:
│ 
│ find_role(config: riocli.config.config.Configuration, project_guid: str = None) -> str
│     Find the role of the user in the project.
│     
│     :param config: Configuration object
│     :param project_guid: GUID of the project
│     
│     :return: Role of the user in the project
│     :raises: SystemExit
```