### PR TITLE
fix(projects): fixes the list command

### DIFF
--- a/riocli/project/__init__.py
+++ b/riocli/project/__init__.py
@@ -18,7 +18,7 @@ from riocli.project.create import create_project
 from riocli.project.delete import delete_project
 from riocli.project.features import features
 from riocli.project.inspect import inspect_project
-from riocli.project.list import list_project
+from riocli.project.list import list_projects
 from riocli.project.select import select_project
 from riocli.project.whoami import whoami
 
@@ -36,7 +36,7 @@ def project() -> None:
     pass
 
 
-project.add_command(list_project)
+project.add_command(list_projects)
 project.add_command(create_project)
 project.add_command(delete_project)
 project.add_command(select_project)

--- a/riocli/project/list.py
+++ b/riocli/project/list.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ from munch import unmunchify
 from rapyuta_io import Project
 
 from riocli.config import new_v2_client
-from riocli.constants import Colors
+from riocli.constants import Colors, Symbols
 from riocli.project.util import name_to_organization_guid
 from riocli.utils import tabulate_data
 
@@ -31,16 +31,28 @@ from riocli.utils import tabulate_data
     help_options_color=Colors.GREEN,
 )
 @click.option('--organization', 'organization_name',
-              help='Pass organization name for which project needs to be created. Default will be current organization')
+              help='List projects for an organization')
 @click.option('--wide', '-w', is_flag=True, default=False,
               help='Print more details', type=bool)
 @click.pass_context
 @name_to_organization_guid
-def list_project(ctx: click.Context = None, organization_guid: str = None,
-                 organization_name: str = None, wide: bool = False) -> None:
+def list_projects(
+        ctx: click.Context = None,
+        organization_guid: str = None,
+        organization_name: str = None,
+        wide: bool = False,
+) -> None:
     """
     List all the projects you are part of
     """
+    # If organization is not passed in the options, use
+    organization_guid = organization_guid or ctx.obj.data.get('organization_id')
+    if organization_guid is None:
+        err_msg = ('Organization not selected. Please set an organization with '
+                   '`rio organization select ORGANIZATION_NAME` or pass the --organization option.')
+        click.secho('{} {}'.format(Symbols.ERROR, err_msg), fg=Colors.RED)
+        raise SystemExit(1)
+
     try:
         client = new_v2_client(with_project=False)
         projects = client.list_projects(organization_guid=organization_guid)


### PR DESCRIPTION
This commit fixes a regression from a previous commit where we have removed the implicit population of organization_guid from the context in the v2Client. As consquence, the list project was fetching the entire list of projects.