### PR TITLE
ci: updates ubuntu runner version in the workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
### Description
The Python dependencies were failing on ubuntu-20.04. Bumping the version to ubuntu-22.04 resolves the issue.