### PR TITLE
fix(auth): saves email_id when logged in with auth_token

### DIFF
--- a/riocli/auth/login.py
+++ b/riocli/auth/login.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ from riocli.auth.util import (
     get_token,
     select_organization,
     select_project,
-    validate_token,
+    validate_and_set_token,
 )
 from riocli.constants import Colors, Symbols
 from riocli.utils.context import get_root_context
@@ -66,9 +66,8 @@ def login(
     ctx = get_root_context(ctx)
 
     if auth_token:
-        if not validate_token(auth_token):
+        if not validate_and_set_token(ctx, auth_token):
             raise SystemExit(1)
-        ctx.obj.data['auth_token'] = auth_token
     else:
         if interactive:
             email = email or click.prompt('Email')

--- a/riocli/auth/util.py
+++ b/riocli/auth/util.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -143,11 +143,10 @@ def get_token(
 
 
 @with_spinner(text='Validating token...')
-def validate_token(token: str, spinner=None) -> bool:
+def validate_and_set_token(ctx: click.Context, token: str, spinner=None) -> bool:
     """Validates an auth token."""
-    config = Configuration()
-    if 'environment' in config.data:
-        os.environ['RIO_CONFIG'] = config.filepath
+    if 'environment' in ctx.obj.data:
+        os.environ['RIO_CONFIG'] = ctx.obj.filepath
 
     client = Client(auth_token=token)
 
@@ -156,6 +155,9 @@ def validate_token(token: str, spinner=None) -> bool:
         spinner.text = click.style(
             'Token belongs to user {}'.format(user.email_id),
             fg=Colors.CYAN)
+        # Save the token and user email_id in the context
+        ctx.obj.data['auth_token'] = token
+        ctx.obj.data['email_id'] = user.email_id
         spinner.ok(Symbols.INFO)
         return True
     except UnauthorizedError:


### PR DESCRIPTION
### Description
This commit fixes the issue where `email_id` of the user is not saved when rio auth login --auth-token TOKEN is invoked.

Wrike Ticket: https://www.wrike.com/open.htm?id=1329601684

### Testing
```
→ rm -f ~/.config/rio-cli/config.json 

→ pipenv run python -m riocli auth login --auth-token X5PdoCZs9O0bAPbohdXiQVt32RUe2N6E81j1foT0 --project sga-sak-002 --organization warehouse --silent
ℹ️ Token belongs to user itaru.fujiwara@rapyuta-robotics.com
Your project has been set to 'sga-sak-002' in the organization 'warehouse'
✅ Logged in successfully!

→ pipenv run python -m riocli project whoami
admin

```