### PR TITLE
fix(configtree): replace --project with --organization flag

### DIFF
--- a/riocli/configtree/revision.py
+++ b/riocli/configtree/revision.py
@@ -41,7 +41,7 @@ class Revision(object):
                  commit: bool = False,
                  force_new: bool = False,
                  spinner: Optional[Yaspin] = None,
-                 with_org: bool = True):
+                 with_project: bool = True):
 
         self._tree_name = tree_name
         self._client = client

--- a/riocli/configtree/tree.py
+++ b/riocli/configtree/tree.py
@@ -49,7 +49,7 @@ def create_config_tree(
     config = get_config_from_context(ctx)
 
     try:
-        client = config.new_v2_client(with_project=with_org)
+        client = config.new_v2_client(with_project=(not with_org))
         payload = {
             "kind": "ConfigTree",
             "apiVersion": "api.rapyuta.io/v2",


### PR DESCRIPTION
### Description

The initial implementation of the configtree provided an option to
operate on project-scoped trees using the --project flag. However, after
considering the use cases, we have come to an understanding that it is
more common to operate on project-scoped trees than the
organization-scoped trees. Hence, this commit replaces the --project
with --organization flag. Specifying the flag means that the user wants
to operate on the organization-scoped config trees only.

### Usage Example
```
→ rio configtree list --help
Usage: rio configtree list [OPTIONS]

  Lists the Config trees.

Options:
  --organization  Operate on organization-scoped Config Trees only.
  --help          Show this message and exit.

```