### PR TITLE
fix(secret): corrects the corresponding find functor

### DIFF
--- a/riocli/apply/resolver.py
+++ b/riocli/apply/resolver.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ class ResolverCache(object, metaclass=_Singleton):
 
     def _guid_functor(self, kind):
         mapping = {
-            'secret': lambda x: munchify(x).guid,
+            'secret': lambda x: munchify(x).metadata.name,
             "project": lambda x: munchify(x).metadata.guid,
             "package": lambda x: munchify(x)['id'],
             "staticroute": lambda x: munchify(x)['metadata']['guid'],
@@ -150,7 +150,7 @@ class ResolverCache(object, metaclass=_Singleton):
 
     def _find_functors(self, kind):
         mapping = {
-            'secret': self._generate_find_guid_functor(),
+            'secret': lambda name, secrets: filter(lambda i: i.metadata.name == name, secrets),
             "project": lambda name, projects: filter(lambda i: i.metadata.name == name, projects),
             "package": lambda name, obj_list, version: filter(
                 lambda x: name == x.name and version == x['packageVersion'], obj_list),

--- a/riocli/secret/model.py
+++ b/riocli/secret/model.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import typing
-from munch import unmunchify
 
+from munch import unmunchify
 from rapyuta_io import Client
 
 from riocli.config import new_v2_client
 from riocli.jsonschema.validate import load_schema
 from riocli.model import Model
+
 
 class Secret(Model):
     def __init__(self, *args, **kwargs):
@@ -51,12 +52,12 @@ class Secret(Model):
         secret = unmunchify(self)
         secret.pop("rc", None)
 
-        r = client.update_secret(obj.name, secret)
+        r = client.update_secret(obj.metadata.name, secret)
         return unmunchify(r)
 
     def delete_object(self, client: Client, obj: typing.Any) -> typing.Any:
         client = new_v2_client()
-        client.delete_secret(obj.name)
+        client.delete_secret(obj.metadata.name)
 
     @classmethod
     def pre_process(cls, client: Client, d: typing.Dict) -> None:


### PR DESCRIPTION
### Description
Due to a recent refactor in the v2 client library,
the list secrets function now returns the entire
secret objects instead of just reading the metadata
in the previous implementation. This changed object
altogther and the way other sections of code fetched
the secret name.

This commit addresses the issue by correcting the
find functions and other methods where secret name is
referred to.