### PR TITLE
feat(vpn): add support for registering machine for Android or iOS

### DIFF
--- a/riocli/v2client/client.py
+++ b/riocli/v2client/client.py
@@ -246,6 +246,17 @@ class Client(object):
 
         return munchify(data)
 
+    def list_instance_bindings(self, instance_name: str, labels: str = '') -> List:
+        """
+        List all managedservice instances in a project
+        """
+        url = "{}/v2/managedservices/{}/bindings/".format(self._host, instance_name)
+        headers = self._get_auth_header()
+
+        client = RestClient(url).method(HttpMethod.GET).headers(headers)
+        return self._walk_pages(client, params={'labelSelector': labels})
+
+
     def create_instance_binding(self, instance_name, binding: dict) -> Munch:
         """
         Create a new managed service instance binding

--- a/riocli/vpn/__init__.py
+++ b/riocli/vpn/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Rapyuta Robotics
+# Copyright 2024 Rapyuta Robotics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ from click_help_colors import HelpColorsGroup
 
 from riocli.vpn.connect import connect
 from riocli.vpn.disconnect import disconnect
+from riocli.vpn.machines import machines
 from riocli.vpn.ping import ping_all
 from riocli.vpn.status import status
 
@@ -37,3 +38,4 @@ vpn.add_command(connect)
 vpn.add_command(disconnect)
 vpn.add_command(status)
 vpn.add_command(ping_all)
+vpn.add_command(machines)

--- a/riocli/vpn/machines.py
+++ b/riocli/vpn/machines.py
@@ -1,0 +1,137 @@
+# Copyright 2024 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Iterable
+import click
+from click_help_colors import HelpColorsCommand, HelpColorsGroup
+from yaspin.core import Yaspin
+
+from riocli.config import new_v2_client
+from riocli.constants.colors import Colors
+from riocli.constants.symbols import Symbols
+from riocli.utils import tabulate_data
+from riocli.utils.spinner import with_spinner
+from riocli.vpn.util import create_binding, get_binding_labels
+
+
+@click.group(
+    invoke_without_command=False,
+    cls=HelpColorsGroup,
+    help_headers_color='yellow',
+    help_options_color='green',
+)
+def machines() -> None:
+    """
+    Manage Android or iOS devices connected to the VPN.
+    """
+    pass
+
+
+@click.command(
+    'list',
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+def list_machines() -> None:
+    """
+    List all the registered Machines on the VPN.
+    """
+    labels = 'machine-key=true'
+
+    try:
+        client = new_v2_client()
+        machines = client.list_instance_bindings('rio-internal-headscale', labels=labels)
+        display_machines(machines=machines)
+    except Exception as e:
+        click.secho(str(e), fg=Colors.RED)
+        raise SystemExit(1) from e
+
+
+@click.command(
+    'register',
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+@click.argument('name', type=str)
+@click.argument('node_key', type=str)
+@click.pass_context
+@with_spinner(text="Registering Machine...")
+def register_machine(ctx: click.Context, name: str, node_key: str, spinner: Yaspin) -> None:
+    """
+    Register an Android or iOS Tailscale Client in the Project VPN.
+    """
+    labels = get_binding_labels()
+    labels['machine-key'] = 'true'
+
+    node_key = sanitize_node_key(node_key)
+
+    try:
+        create_binding(ctx, name=name, machine=node_key, ephemeral=False, throwaway=False, labels=labels)
+        spinner.text = click.style('Machine {} registered successfully.'.format(name), fg=Colors.GREEN)
+        spinner.green.ok(Symbols.SUCCESS)
+    except Exception as e:
+        spinner.text = click.style(
+            'Failed to register: {}'.format(e), Colors.RED)
+        spinner.red.fail(Symbols.ERROR)
+        raise SystemExit(1) from e
+
+
+@click.command(
+    'deregister',
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+@click.argument('name', type=str)
+@with_spinner(text="De-registering Machine...")
+def deregister_machine(name: str, spinner: Yaspin) -> None:
+    """
+    Register an Android or iOS Tailscale Client in the Project VPN.
+    """
+
+    try:
+        client = new_v2_client()
+        client.delete_instance_binding("rio-internal-headscale", name)
+        spinner.text = click.style('Machine {} de-registered successfully.'.format(name), fg=Colors.GREEN)
+        spinner.green.ok(Symbols.SUCCESS)
+    except Exception as e:
+        spinner.text = click.style(
+            'Failed to de-register: {}'.format(e), Colors.RED)
+        spinner.red.fail(Symbols.ERROR)
+        raise SystemExit(1) from e
+
+
+def display_machines(machines: Iterable, show_header: bool = True) -> None:
+    headers = []
+    if show_header:
+        headers = ['Machine Name']
+
+    data = []
+    for machine in machines:
+        data.append([machine.metadata.name])
+
+    tabulate_data(data, headers=headers)
+
+
+def sanitize_node_key(node_key: str) -> str:
+    if node_key.startswith('nodekey:'):
+        return node_key
+
+    return 'nodekey:{}'.format(node_key)
+
+
+machines.add_command(register_machine)
+machines.add_command(deregister_machine)
+machines.add_command(list_machines)


### PR DESCRIPTION
### Description

This PR introduces a subcommand to manage Android and iOS devices on rapyuta.io VPN. Run the following command to know more.
```
rio vpn machines --help
```