### PR TITLE
fix(vpn): fix the expiry time formatting for vpn binding

### DIFF
--- a/riocli/vpn/util.py
+++ b/riocli/vpn/util.py
@@ -188,7 +188,7 @@ def get_key_expiry_time(delta: Optional[timedelta]) -> Optional[str]:
         return None
 
     expiry = datetime.utcnow() + delta
-    return expiry.isoformat('T')
+    return expiry.isoformat('T') + 'Z'
 
 def get_binding_labels() -> dict:
     return {


### PR DESCRIPTION
### Description

This commit fixes the expiry time format while generating a managed service binding in the `rio vpn connect` command.