### PR TITLE
🐛 fix(apply): fixes the secret guid functor in the resolver

### DIFF
--- a/riocli/apply/resolver.py
+++ b/riocli/apply/resolver.py
@@ -116,7 +116,7 @@ class ResolverCache(object, metaclass=_Singleton):
 
     def _guid_functor(self, kind):
         mapping = {
-            'secret': lambda x: munchify(x).metadata.name,
+            'secret': lambda x: munchify(x).metadata.guid,
             "project": lambda x: munchify(x).metadata.guid,
             "package": lambda x: munchify(x)['id'],
             "staticroute": lambda x: munchify(x)['metadata']['guid'],


### PR DESCRIPTION
### Description
While fixing a regression, the guid  functor for secret was updated to return a name. This led to a regression in the apply command where secrets created along with other packages weren't being resolved correctly. This commit fixes that.

### Testing
Used the following test manifest:
```yaml
---
apiVersion: apiextensions.rapyuta.io/v1
kind: Secret
metadata:
  name: test-secret
spec:
  type: Docker
  docker:
    registry: quay.io/rapyuta
    username: "quayuser"
    password: "quaypass"
    email: rr@rr.com
---
apiVersion: "apiextensions.rapyuta.io/v1"
kind: Package
metadata:
  name: "nginx"
  version: "1.0.0"
  labels:
    app: nginx
spec:
  runtime: cloud
  cloud:
    replicas: 1
  executables:
    - name: nginx
      type: docker
      docker:
        image: nginx
        pullSecret:
          depends:
            kind: secret
            nameOrGUID: "test-secret"
```