### PR TITLE
feat(template): sort rendered template by file name

### DIFF
--- a/riocli/apply/util.py
+++ b/riocli/apply/util.py
@@ -57,5 +57,5 @@ def process_files_values_secrets(files, values, secrets):
         if abs_secrets in glob_files:
             glob_files.remove(abs_secrets)
 
-    glob_files = list(set(glob_files))
+    glob_files = sorted(list(set(glob_files)))
     return glob_files, abs_values, abs_secret


### PR DESCRIPTION
The output of the rio template command is currently
not sorted by file name. This makes it slightly
inconvenient to read through the rendered templates.

In this commit, we sort the files before rendering them.