### PR TITLE
fix(jsonschema): add platform as a product for virtual devices

### DIFF
--- a/riocli/apply/manifests/device.yaml
+++ b/riocli/apply/manifests/device.yaml
@@ -67,7 +67,7 @@ spec:
   rosDistro: "melodic" # Options: ["kinetic", "melodic" (default), "noetic"]
   virtual:
     enabled: True # Required
-    product: "sootballs" # Required Options: ["sootballs", "flaptter", "oks"]
+    product: "sootballs" # Required Options: ["sootballs", "flaptter", "oks", "platform"]
     arch: "amd64" # Options: ["amd64" (default), "arm64" ]
     os: "ubuntu" # Options: ["ubuntu" (default), "debian" ]
     codename: "focal" # Options: ["bionic", "focal" (default), "jammy", "bullseye"]

--- a/riocli/jsonschema/schemas/device-schema.yaml
+++ b/riocli/jsonschema/schemas/device-schema.yaml
@@ -73,6 +73,7 @@ definitions:
                   - sootballs
                   - flaptter
                   - oks
+                  - platform
               arch:
                 type: string
                 enum:


### PR DESCRIPTION
### Description
Users can now set platform as a product type when they create virtual devices using device manifests.

Wrike Ticket: https://www.wrike.com/open.htm?id=1460556021