### PR TITLE
fix(organization): fix organization select command

### DIFF
--- a/riocli/organization/select.py
+++ b/riocli/organization/select.py
@@ -51,7 +51,7 @@ def select_organization(
     """
     ctx = get_root_context(ctx)
 
-    if ctx.obj.data['organization_id'] == organization_guid:
+    if ctx.obj.data.get('organization_id') == organization_guid:
         click.secho("You are already in the '{}' organization".format(
             organization_name), fg=Colors.GREEN)
         return


### PR DESCRIPTION
The organization select command checks whether the currently set organization is already the selected one. It relies on the organization_id in the config. However, there may be a case where the config may not have the organization entry. In such a case, accessing the key without .get() throws a key error. This commit rectifies the issue.

Wrike Ticket: