### PR TITLE
feat(vpn): adds option to populate vpn peers in hosts file

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -3,16 +3,16 @@ on: [ push ]
 
 jobs:
   python-compatibility:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/Pipfile
+++ b/Pipfile
@@ -37,6 +37,7 @@ python-benedict = ">=0.33.2"
 etcd3gw = ">=2.4.0"
 graphviz = ">=0.20.3"
 python-magic = ">=0.4.27"
+python-hosts = "*"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4e319b6393394ee2fbbdc309e3ca4a4e0d59572e9f1b5c876c0a643624b98f0f"
+            "sha256": "80fe2a6e5f371cd5d47d31db7d52b0be316a86ebce761d97bc32eaedc2e30713"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -263,11 +263,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
-                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8"
+            "version": "==3.10"
         },
         "jinja2": {
             "hashes": [
@@ -425,6 +425,14 @@
                 "sha256:8fb204fa8059f37bdeee8a1dc0fff010170202ea47c4225ee71bb3c26f3997be"
             ],
             "version": "==0.14.1"
+        },
+        "python-hosts": {
+            "hashes": [
+                "sha256:4c56991e22f6bffc28096833de787f92350e85b7cdd6086706725c55c4f04ab9",
+                "sha256:7fb9c42e2f75d6e2c2ef7e11ffd7aa6a7d59a1fb54bcc5d0f0bba021aa8d5175"
+            ],
+            "index": "pypi",
+            "version": "==1.0.7"
         },
         "python-magic": {
             "hashes": [
@@ -658,11 +666,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308",
-                "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"
+                "sha256:35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2",
+                "sha256:d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==74.1.2"
+            "version": "==75.1.0"
         },
         "shellingham": {
             "hashes": [
@@ -947,11 +955,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
-                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8"
+            "version": "==3.10"
         },
         "imagesize": {
             "hashes": [
@@ -1100,11 +1108,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c",
-                "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"
+                "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907",
+                "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.3.2"
+            "version": "==4.3.6"
         },
         "plette": {
             "extras": [
@@ -1259,11 +1267,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308",
-                "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"
+                "sha256:35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2",
+                "sha256:d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==74.1.2"
+            "version": "==75.1.0"
         },
         "six": {
             "hashes": [

--- a/riocli/auth/login.py
+++ b/riocli/auth/login.py
@@ -22,6 +22,7 @@ from riocli.auth.util import (
 )
 from riocli.constants import Colors, Symbols
 from riocli.utils.context import get_root_context
+from riocli.vpn.util import cleanup_hosts_file
 
 LOGIN_SUCCESS = click.style('{} Logged in successfully!'.format(Symbols.SUCCESS), fg=Colors.GREEN)
 
@@ -124,5 +125,11 @@ def login(
     select_project(ctx.obj, project=project, organization=organization)
 
     ctx.obj.save()
+
+    try:
+        cleanup_hosts_file()
+    except Exception as e:
+        click.secho(f'{Symbols.WARNING} Failed to '
+                    f'clean up hosts file: {str(e)}', fg=Colors.YELLOW)
 
     click.echo(LOGIN_SUCCESS)

--- a/riocli/organization/select.py
+++ b/riocli/organization/select.py
@@ -20,6 +20,7 @@ from riocli.auth.util import select_project
 from riocli.constants import Colors
 from riocli.project.util import name_to_organization_guid
 from riocli.utils.context import get_root_context
+from riocli.vpn.util import cleanup_hosts_file
 
 
 @click.command(
@@ -71,5 +72,10 @@ def select_organization(
             "Please set your project with `rio project select PROJECT_NAME`".format(organization_name),
             fg=Colors.GREEN)
 
-
     ctx.obj.save()
+
+    try:
+        cleanup_hosts_file()
+    except Exception as e:
+        click.secho(f'{Symbols.WARNING} Failed to '
+                    f'clean up hosts file: {str(e)}', fg=Colors.YELLOW)

--- a/riocli/project/select.py
+++ b/riocli/project/select.py
@@ -17,6 +17,7 @@ from click_help_colors import HelpColorsCommand
 from riocli.constants import Colors, Symbols
 from riocli.project.util import name_to_guid
 from riocli.utils.context import get_root_context
+from riocli.vpn.util import cleanup_hosts_file
 
 
 @click.command(
@@ -41,6 +42,12 @@ def select_project(
     ctx.obj.data['project_id'] = project_guid
     ctx.obj.data['project_name'] = project_name
     ctx.obj.save()
+
+    try:
+        cleanup_hosts_file()
+    except Exception as e:
+        click.secho(f'{Symbols.WARNING} Failed to '
+                    f'clean up hosts file: {str(e)}', fg=Colors.YELLOW)
 
     click.secho('{} Project {} ({}) is selected!'.format(
         Symbols.SUCCESS,

--- a/riocli/vpn/connect.py
+++ b/riocli/vpn/connect.py
@@ -14,6 +14,7 @@
 
 
 from datetime import timedelta
+
 import click
 from click_help_colors import HelpColorsCommand
 from yaspin.api import Yaspin
@@ -29,11 +30,12 @@ from riocli.vpn.util import (
     priviledged_command,
     stop_tailscale,
     install_vpn_tools,
-    is_vpn_enabled_in_project
+    is_vpn_enabled_in_project,
+    update_hosts_file
 )
 
 _TAILSCALE_CMD_FORMAT = 'tailscale up --auth-key={} --login-server={} --reset --force-reauth ' \
-'--accept-routes --accept-dns --advertise-tags={} --timeout=30s'
+                        '--accept-routes --accept-dns --advertise-tags={} --timeout=30s'
 
 
 @click.command(
@@ -42,9 +44,13 @@ _TAILSCALE_CMD_FORMAT = 'tailscale up --auth-key={} --login-server={} --reset --
     help_headers_color=Colors.YELLOW,
     help_options_color=Colors.GREEN,
 )
+@click.option('--update-hosts', 'update_hosts', is_flag=True,
+              default=False, help='Update hosts file with VPN peers to allow '
+                                  'access to them by hostname. Run with `sudo` '
+                                  'when you enable this flag.')
 @click.pass_context
 @with_spinner(text="Connecting...")
-def connect(ctx: click.Context, spinner: Yaspin):
+def connect(ctx: click.Context, update_hosts: bool, spinner: Yaspin):
     """
     Connect to the current project's VPN network
     """
@@ -91,7 +97,15 @@ def connect(ctx: click.Context, spinner: Yaspin):
                 Symbols.ERROR), fg=Colors.RED)
             raise SystemExit(1)
 
-        spinner.green.text = 'You are now connected to the project\'s VPN'
+        if update_hosts and is_tailscale_up():
+            spinner.text = 'Updating hosts file...'
+            try:
+                update_hosts_file()
+                spinner.write(click.style(f'{Symbols.SUCCESS} Hosts file updated', fg=Colors.CYAN))
+            except Exception as e:
+                spinner.write(click.style(f'Failed to update hosts: {str(e)}', fg=Colors.RED))
+
+        spinner.text = click.style('You are now connected to the project\'s VPN', fg=Colors.GREEN)
         spinner.green.ok(Symbols.SUCCESS)
     except click.exceptions.Abort as e:
         spinner.red.text = 'Aborted!'
@@ -120,5 +134,3 @@ def start_tailscale(ctx: click.Context, spinner: Yaspin) -> bool:
         return False
 
     return True
-
-

--- a/riocli/vpn/disconnect.py
+++ b/riocli/vpn/disconnect.py
@@ -19,7 +19,8 @@ from riocli.constants import Colors, Symbols
 from riocli.vpn.util import (
     install_vpn_tools,
     is_tailscale_up,
-    stop_tailscale
+    stop_tailscale,
+    cleanup_hosts_file,
 )
 
 
@@ -44,6 +45,12 @@ def disconnect(ctx: click.Context):
                 fg=Colors.RED)
             raise SystemExit(1)
 
+        try:
+            cleanup_hosts_file()
+        except Exception as e:
+            click.secho(f'{Symbols.WARNING} Could not clean '
+                        f'up hosts file: {str(e)}', fg=Colors.YELLOW)
+
         click.secho(
             '{} You have been disconnected from the project\'s VPN'.format(
                 Symbols.SUCCESS),
@@ -51,3 +58,5 @@ def disconnect(ctx: click.Context):
     except Exception as e:
         click.secho(str(e), fg=Colors.RED)
         raise SystemExit(1) from e
+
+

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "etcd3gw>=2.4.0",
         "graphviz>=0.20.3",
         "python-magic>=0.4.27",
+        "python-hosts>=1.0.7",
     ],
     setup_requires=["flake8"],
 )


### PR DESCRIPTION
### Description

Since our headscale runs without `magicDNS` enabled, it is impossible to resolve VPN peers using their DNS names. `magicDNS` cannot be enabled since we have faced multiple DNS resolution-related issues in the past that break the VPN connectivity in warehouses.

However, VPN users in Flaptter have requested the ability to access devices and services running on them via hostnames. 

To fulfill the requirement, this PR populates the hosts file on a user's system with the devices on rapyuta.io that have VPN enabled. Thus, it is possible to access any device via its hostname when connected over VPN.

To use the feature, users will have to run the following command
```
rio vpn connect --update-hosts
```

### Testing

https://github.com/user-attachments/assets/26cd6d08-f9cc-4ce8-8fff-cac12f22078e

