### PR TITLE
feat(apply): adds template func to get interface ip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "python-magic>=0.4.27",
     "pytz",
     "pyyaml>=5.4.1",
-    "rapyuta-io>=2.0.0",
+    "rapyuta-io>=2.1.0",
     "requests>=2.20.0",
     "semver>=3.0.0",
     "setuptools",

--- a/riocli/apply/filters.py
+++ b/riocli/apply/filters.py
@@ -11,17 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Filters to use in the manifests.
 """
-
 import os
+
+from riocli.config import new_client
+from riocli.device.util import find_device_guid
 
 
 def getenv(default: str, env_var: str) -> str:
-    """
-    Get the value of an environment variable.
+    """Get the value of an environment variable.
 
     Usage:
         "foo" : {{ "bar" | getenv('FOO') }}
@@ -36,6 +36,41 @@ def getenv(default: str, env_var: str) -> str:
     return os.getenv(env_var, default)
 
 
+def get_interface_ip(device_name: str, interface: str) -> str:
+    """Get the IP address of an interface on a device.
+
+    Usage:
+        "ip" : {{ device_name | get_intf_ip(interface='intf-name') }}
+
+    Args:
+        device_name: The name of the device.
+        interface: The name of the interface.
+
+    Returns:
+        The IP address of the interface
+
+    Raises:
+        Exception: If the interface is not available on the device.
+    """
+    client = new_client(with_project=True)
+    device_id = find_device_guid(client, device_name)
+
+    device = client.get_device(device_id)
+    try:
+        device.poll_till_ready(retry_count=50, sleep_interval=10)
+    except Exception as e:
+        raise e
+
+    device.refresh()
+
+    for name in device.ip_interfaces:
+        if name == interface:
+            return device.ip_interfaces[name][0]
+
+    raise Exception(f'interface "{interface}" not found on device "{device_name}"')
+
+
 FILTERS = {
     "getenv": getenv,
+    "get_intf_ip": get_interface_ip,
 }

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ wheels = [
 
 [[package]]
 name = "rapyuta-io"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
@@ -714,9 +714,9 @@ dependencies = [
     { name = "six" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/aa/a4a052fc00dfbb807a81af070997fce37b9ad8680c1d7dfb2d9adb173dd6/rapyuta_io-2.0.0.tar.gz", hash = "sha256:b50ff90b4e1fb6f925f2ab30d5af8ea1c533fb148b8c3a743fcd8c37fd9ea391", size = 51418 }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/5a/5b33695b8cccc95dee9720539818862f3f1db1d0c193f2e3ebfb4c06ad63/rapyuta_io-2.1.0.tar.gz", hash = "sha256:83519f28b5e79be75a339d8fa61442cb60fa433c75d71a8711dc56393b32b808", size = 51474 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/fe/16a483003ada3350fa39fd5356c49d6fb32b0b9ff50e95c43cec5f68ffbd/rapyuta_io-2.0.0-py3-none-any.whl", hash = "sha256:fadc7f50f9a8f1b3cd9cbac0b9ba4253bf8374d26da26ebfadc52c42851fcc93", size = 59878 },
+    { url = "https://files.pythonhosted.org/packages/10/79/675123b94a77aa32c4a7581d385c27522d490ef76118dbdf0d73594a4d63/rapyuta_io-2.1.0-py3-none-any.whl", hash = "sha256:aedfdbe51a3707e5343257998227732f98cacec47a59438ce8b8e5b228178f17", size = 59908 },
 ]
 
 [[package]]
@@ -792,7 +792,7 @@ requires-dist = [
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "pytz" },
     { name = "pyyaml", specifier = ">=5.4.1" },
-    { name = "rapyuta-io", specifier = ">=2.0.0" },
+    { name = "rapyuta-io", specifier = ">=2.1.0" },
     { name = "requests", specifier = ">=2.20.0" },
     { name = "semver", specifier = ">=3.0.0" },
     { name = "setuptools" },


### PR DESCRIPTION
### Description
This PR implements the `get_intf_ip` template filter that will help fetch the IP of a device interface. Here's an example
```yaml
envArgs:
- name: EDGE_VPN_IP
  value: {{ 'edge01' | get_intf_ip(interface='tailscale0') }}
```

Note: This will introduce a slight delay in applying the template.

### Depends
* https://github.com/rapyuta-robotics/rapyuta-io-sdk/pull/84