### PR TITLE
fix(organization): fixes key error when no org is selected

### DIFF
--- a/riocli/organization/list.py
+++ b/riocli/organization/list.py
@@ -36,7 +36,7 @@ def list_organizations(ctx: click.Context) -> None:
     try:
         client = new_client(with_project=False)
         organizations = client.get_user_organizations()
-        current = ctx.obj.data["organization_id"]
+        current = ctx.obj.data.get("organization_id")
         print_organizations(organizations, current)
     except Exception as e:
         click.secho(str(e), fg=Colors.RED)


### PR DESCRIPTION
### Description

When we login with auth token in silent mode, there's no org selected. The config has no org present either. This breaks the list command that tries to fetch the selected org from config to highlight it in the output.

```
03:26:43 pallab@pop-os rr_flaptter_deploy ±|devel ✗|
→ rio organization list
'organization_id'
03:26:51 pallab@pop-os rr_flaptter_deploy ±|devel ✗|
→ cat ~/.config/rio-cli/config.json 
───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /home/pallab/.config/rio-cli/config.json
───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ {"hwil_auth_token": "TOKEN", "machine_id": "63eed7ba-49f7-4de5-8811-95f46bc88137", "email_id": "amit.singh@rapyuta-robotics.com", "auth_token": "TOKEN"}
───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


```