### PR TITLE
feat(deployment): adds an option to block paramsync until ready

### DIFF
--- a/riocli/apply/manifests/deployment-nonros-device.yaml
+++ b/riocli/apply/manifests/deployment-nonros-device.yaml
@@ -16,6 +16,13 @@ spec:
       kind: device
       nameOrGUID: device-docker
   restart: always # Options: [always, onfailure, never]
+  features:
+    params:
+      enabled: true
+      trees:
+        - config01
+        - config02
+      blockUntilSynced: true # Optional [true, false]. Default is false.
   envArgs:
     - name: TEST_KEY
       value: test_value

--- a/riocli/apply/manifests/deployment.yaml
+++ b/riocli/apply/manifests/deployment.yaml
@@ -287,6 +287,13 @@ spec:
       kind: device
       nameOrGUID: device-docker
   restart: always # Options: [always, onfailure, never]
+  features:
+    params:
+      enabled: true
+      trees:
+        - config01
+        - config02
+      blockUntilSynced: true # Optional [true, false]. Default is false.
   envArgs:
     - name: TEST_KEY
       value: test_value

--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -174,8 +174,12 @@ definitions:
                           type: string
                       disableSync:
                         type: boolean
+                      blockUntilSynced:
+                        type: boolean
+                        default: false
                     required:
                       - enabled
+                      - trees
             type: object
             additionalProperties: false
 
@@ -211,6 +215,7 @@ definitions:
                         type: boolean
                     required:
                       - enabled
+                      - trees
               envArgs:
                 type: array
                 items:


### PR DESCRIPTION
### Resolves

Resolves [AB#33922](https://dev.azure.com/rapyuta-robotics/3151e969-9eb7-4729-b4e8-8c659c416104/_workitems/edit/33922)