### PR TITLE
feat: adds option for virtual device expiry

### DIFF
--- a/riocli/apply/manifests/device.yaml
+++ b/riocli/apply/manifests/device.yaml
@@ -70,6 +70,7 @@ spec:
     codename: "focal" # Options: ["bionic", "focal" (default), "jammy", "bullseye"]
     highperf: False # Optional [True, False (default)]
     wait: True # Optional [True, False (default)] Wait until the device is ready.
+    expireAfter: '12h' # Optional ["s", "m", "h", "d"] Expire after set duration.
   docker:
     enabled: True # Required
     rosbagMountPath: "/opt/rapyuta/volumes/rosbag"

--- a/riocli/device/util.py
+++ b/riocli/device/util.py
@@ -301,6 +301,7 @@ def make_hwil_labels(spec: dict, device_name: str) -> typing.Dict:
         "project": data["project_id"],
         "product": spec["product"],
         "rapyuta_device_name": device_name,
+        "expiry_after": spec["expireAfter"],
     }
 
     if spec.get("highperf", False):

--- a/riocli/hwil/create.py
+++ b/riocli/hwil/create.py
@@ -49,6 +49,13 @@ from riocli.utils.spinner import with_spinner
     type=click.Choice(["bionic", "focal", "jammy", "bullseye"]),
     default="focal",
 )
+@click.option(
+    "--expire-after",
+    "expire_after",
+    help="Duration after which the device will expire. Example: 12h, 1d, 600s, 10m",
+    type=str,
+    default="12h",
+)
 @click.argument("device-name", type=str)
 @with_spinner(text="Creating device...")
 @click.pass_context
@@ -58,6 +65,7 @@ def create_device(
     arch: str,
     os: str,
     codename: str,
+    expire_after: str,
     spinner: Yaspin = None,
 ) -> None:
     """Create a new hardware-in-the-loop device.
@@ -78,11 +86,11 @@ def create_device(
 
       Create a new device with the name 'my-device' and the default
 
-      $ rio hwil create my-device
+        $ rio hwil create my-device
 
-        Create a new device with the name 'my-device' and custom
-        parameters for example, arm64 architecture, debian OS and
-        bullseye codename.
+      Create a new device with the name 'my-device' and custom
+      parameters for example, arm64 architecture, debian OS and
+      bullseye codename.
 
         $ rio hwil create my-device --arch arm64 --os debian --codename bullseye
 
@@ -97,6 +105,8 @@ def create_device(
     spinner.write(info)
     client = new_hwil_client()
     labels = prepare_device_labels_from_context(ctx)
+
+    labels["expiry_after"] = expire_after
 
     try:
         client.create_device(device_name, arch, os, codename, labels)

--- a/riocli/jsonschema/schemas/device-schema.yaml
+++ b/riocli/jsonschema/schemas/device-schema.yaml
@@ -100,6 +100,10 @@ definitions:
               highperf:
                 type: boolean
                 default: False
+              expireAfter:
+                type: string
+                format: duration
+                default: 12h
             required:
               - enabled
               - product


### PR DESCRIPTION
### Description

Introduces support for specifying device expiry in the manifest as well as the `rio hwil` command. 