### PR TITLE
feat: add RIO_CONFIG env override

### DIFF
--- a/riocli/config/config.py
+++ b/riocli/config/config.py
@@ -56,7 +56,7 @@ class Configuration(object):
     MERGE_TOOL = "vimdiff"
 
     def __init__(self, filepath: Optional[str] = None):
-        self._filepath = filepath
+        self._filepath = os.environ.get("RIO_CONFIG", filepath)
         self.exists = True
 
         # If config file does not exist, then initialize an empty dictionary instead.


### PR DESCRIPTION
Overrides the CLI config filepath with the RIO_CONFIG env variable if set.

Use case
Automating parallel deployments with the RIO CLI as done in

https://github.com/rapyuta-robotics/rr_lsd_staging

deploy.py 

Usage like
RIO_CONFIG=./path/to/config.json rio project list
