### PR TITLE
feat(device): handles failed hwil devices during apply and delete

### DIFF
--- a/riocli/apply/manifests/device.yaml
+++ b/riocli/apply/manifests/device.yaml
@@ -64,7 +64,7 @@ spec:
   rosDistro: "melodic" # Options: ["kinetic", "melodic" (default), "noetic"]
   virtual:
     enabled: True # Required
-    product: "sootballs" # Required Options: ["sootballs", "flaptter", "oks", "platform"]
+    product: "sootballs" # Optional: ["sootballs", "flaptter", "oks"]
     arch: "amd64" # Options: ["amd64" (default), "arm64" ]
     os: "ubuntu" # Options: ["ubuntu" (default), "debian" ]
     codename: "focal" # Options: ["bionic", "focal" (default), "jammy", "noble", "bullseye"]

--- a/riocli/device/util.py
+++ b/riocli/device/util.py
@@ -250,7 +250,11 @@ def generate_hwil_device_name(
 ) -> str:
     """Generates a valid hardware-in-the-loop device name."""
     project = project_id.split("project-")[1]
-    return sanitize_hwil_device_name(f"{name}-{product}-{user}-{project}")
+    device_name = f"{name}-{product}-{user}-{project}"
+    if not product:
+        device_name = f"{name}-{user}-{project}"
+
+    return sanitize_hwil_device_name(device_name)
 
 
 def create_hwil_device(spec: dict, metadata: dict) -> Munch:
@@ -258,7 +262,7 @@ def create_hwil_device(spec: dict, metadata: dict) -> Munch:
     os = spec["os"]
     codename = spec["codename"]
     arch = spec["arch"]
-    product = spec["product"]
+    product = spec.get("product")
     name = metadata["name"]
 
     labels = make_hwil_labels(spec, name)
@@ -294,7 +298,7 @@ def create_hwil_device(spec: dict, metadata: dict) -> Munch:
 
 def delete_hwil_device(spec: dict, metadata: dict) -> None:
     """Delete a hardware-in-the-loop device by name."""
-    product = spec["product"]
+    product = spec.get("product")
     name = metadata["name"]
     labels = make_hwil_labels(spec, name)
     device_name = generate_hwil_device_name(
@@ -329,13 +333,12 @@ def make_hwil_labels(spec: dict, device_name: str) -> typing.Dict:
         "user": user_email,
         "organization": data["organization_id"],
         "project": data["project_id"],
-        "product": spec["product"],
         "rapyuta_device_name": device_name,
         "expiry_after": spec["expireAfter"],
     }
 
-    if spec.get("highperf", False):
-        labels["highperf"] = ""
+    if "product" in spec:
+        labels["product"] = spec["product"]
 
     return labels
 

--- a/riocli/hwilclient/client.py
+++ b/riocli/hwilclient/client.py
@@ -212,11 +212,17 @@ class Client(object):
         msg = f"Retries exhausted: Tried {retry_limit} times with {sleep_interval}s interval."
         raise RetriesExhausted(msg)
 
-    def list_devices(self: Client):
+    def list_devices(self: Client, query: dict = None) -> Munch:
         """Fetch all HWIL devices"""
         url = f"{self._host}/device/"
         headers = self._get_auth_header()
-        response = RestClient(url).method(HttpMethod.GET).headers(headers).execute()
+        response = (
+            RestClient(url)
+            .method(HttpMethod.GET)
+            .headers(headers)
+            .query_param(query or {})
+            .execute()
+        )
         handle_server_errors(response)
 
         data = json.loads(response.text)

--- a/riocli/jsonschema/schemas/device-schema.yaml
+++ b/riocli/jsonschema/schemas/device-schema.yaml
@@ -76,7 +76,6 @@ definitions:
                   - sootballs
                   - flaptter
                   - oks
-                  - platform
               arch:
                 type: string
                 enum:
@@ -106,7 +105,6 @@ definitions:
                 default: 12h
             required:
               - enabled
-              - product
     dependencies:
       docker:
         oneOf:

--- a/uv.lock
+++ b/uv.lock
@@ -721,7 +721,7 @@ wheels = [
 
 [[package]]
 name = "rapyuta-io-cli"
-version = "9.0.4"
+version = "9.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "argparse" },


### PR DESCRIPTION
### Description

This pull request includes the following set of changes
* ✨ Adds project id to the `hwil` device name when a virtual device is created using a device manifest.
* 🐛 When a hwil device goes into a failed state while applying a device manifest and the rio device isn't created, the `rio delete` operation fails to clean it up since it returns when the rio device is not found. This pull request fixes that by attempting to clean-up if a corresponding hwil device exists.
* 🐛 Let's say a previous apply led to the hwil device going into the failed state, re-applying the manifest doesn't clean-up the device and returns the details of the existing failed device. This renders the re-apply useless. This pull request fixes that by cleaning up the failed hwil device and re-creating it.

Resolves [AB#39731](https://dev.azure.com/rapyuta-robotics/3151e969-9eb7-4729-b4e8-8c659c416104/_workitems/edit/39731)