### PR TITLE
feat(device): execute command on multiple devices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "python-magic>=0.4.27",
     "pytz",
     "pyyaml>=5.4.1",
-    "rapyuta-io>=2.2.2",
+    "rapyuta-io>=2.3.0",
     "requests>=2.20.0",
     "semver>=3.0.0",
     "setuptools",

--- a/riocli/device/execute.py
+++ b/riocli/device/execute.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import typing
-
 import click
 from click_help_colors import HelpColorsCommand
-
+from riocli.config import new_client
 from riocli.constants import Colors
-from riocli.device.util import name_to_guid
-from riocli.utils.execute import run_on_device
+from riocli.device.util import fetch_devices
+from rapyuta_io import Command
+from shlex import join
 
 
 @click.command(
@@ -37,19 +37,17 @@ from riocli.utils.execute import run_on_device
     default=False,
     help="Run the command asynchronously.",
 )
-@click.argument("device-name", type=str)
+@click.argument("device-name-or-regex", type=str)
 @click.argument("command", nargs=-1)
-@name_to_guid
 def execute_command(
-    device_name: str,
-    device_guid: str,
+    device_name_or_regex: str,
     user: str,
     timeout: int,
     shell: str,
     run_async: bool,
     command: typing.List[str],
 ) -> None:
-    """Execute commands on a device.
+    """Execute commands on one or more devices.
 
     You can specify the user, shell, run-async, and timeout options to customize
     the command execution. To specify the user, use the --user flag.
@@ -63,19 +61,44 @@ def execute_command(
 
     Usage Examples:
 
-        $ rio device execute DEVICE_NAME "ls -l"
-    """
-    try:
-        response = run_on_device(
-            device_guid=device_guid,
-            user=user,
-            shell=shell,
-            command=command,
-            background=run_async,
-            timeout=timeout,
-        )
+        $ rio device execute DEVICE_NAME_OR_REGEX "ls -l"
 
-        click.secho(response)
+        To execute the command asynchronously:
+
+            $ rio device execute DEVICE_NAME_OR_REGEX "ls -l" --async
+
+        To run the command on all devices:
+
+            $ rio device execute ".*" "ls -l"
+    """
+
+    client = new_client()
+
+    try:
+        devices = fetch_devices(
+            client, device_name_or_regex, include_all=False, online_devices=True
+        )
     except Exception as e:
         click.secho(str(e), fg=Colors.RED)
         raise SystemExit(1) from e
+
+    if not devices:
+        click.secho("No device(s) found", fg=Colors.RED)
+        raise SystemExit(1)
+
+    device_guids = [d.uuid for d in devices if d.status == "ONLINE"]
+    device_dict = {d.uuid: d.name for d in devices}
+    cmd = join(tuple(["bash", "-c"]) + command)
+    try:
+        result = client.execute_command(
+            device_ids=device_guids,
+            command=Command(cmd, shell=shell, bg=run_async, runas=user, timeout=timeout),
+            timeout=timeout,
+        )
+        for device_guid in result:
+            click.secho(">>> {}({})".format(device_dict[device_guid], device_guid), fg=Colors.YELLOW)
+            click.echo("{}\n".format(result[device_guid]))
+    except Exception as e:
+        click.secho(str(e), fg=Colors.RED)
+        raise SystemExit(1) from e
+

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.8.10"
 
 [[package]]
@@ -258,7 +259,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -347,7 +348,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/65/13d9e76ca19b0ba5603d71ac8424b5694415b348e719db277b5edc985ff5/cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb", size = 3915420 },
     { url = "https://files.pythonhosted.org/packages/b1/07/40fe09ce96b91fc9276a9ad272832ead0fddedcba87f1190372af8e3039c/cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b", size = 4154498 },
     { url = "https://files.pythonhosted.org/packages/75/ea/af65619c800ec0a7e4034207aec543acdf248d9bffba0533342d1bd435e1/cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543", size = 3932569 },
-    { url = "https://files.pythonhosted.org/packages/4e/d5/9cc182bf24c86f542129565976c21301d4ac397e74bf5a16e48241aab8a6/cryptography-44.0.0-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:60eb32934076fa07e4316b7b2742fa52cbb190b42c2df2863dbc4230a0a9b385", size = 4164756 },
     { url = "https://files.pythonhosted.org/packages/c7/af/d1deb0c04d59612e3d5e54203159e284d3e7a6921e565bb0eeb6269bdd8a/cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e", size = 4016721 },
     { url = "https://files.pythonhosted.org/packages/bd/69/7ca326c55698d0688db867795134bdfac87136b80ef373aaa42b225d6dd5/cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e", size = 4240915 },
     { url = "https://files.pythonhosted.org/packages/ef/d4/cae11bf68c0f981e0413906c6dd03ae7fa864347ed5fac40021df1ef467c/cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053", size = 2757925 },
@@ -358,7 +358,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/c7/c656eb08fd22255d21bc3129625ed9cd5ee305f33752ef2278711b3fa98b/cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289", size = 3915417 },
     { url = "https://files.pythonhosted.org/packages/ef/82/72403624f197af0db6bac4e58153bc9ac0e6020e57234115db9596eee85d/cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7", size = 4155160 },
     { url = "https://files.pythonhosted.org/packages/a2/cd/2f3c440913d4329ade49b146d74f2e9766422e1732613f57097fea61f344/cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c", size = 3932331 },
-    { url = "https://files.pythonhosted.org/packages/31/d9/90409720277f88eb3ab72f9a32bfa54acdd97e94225df699e7713e850bd4/cryptography-44.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9abcc2e083cbe8dde89124a47e5e53ec38751f0d7dfd36801008f316a127d7ba", size = 4165207 },
     { url = "https://files.pythonhosted.org/packages/7f/df/8be88797f0a1cca6e255189a57bb49237402b1880d6e8721690c5603ac23/cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64", size = 4017372 },
     { url = "https://files.pythonhosted.org/packages/af/36/5ccc376f025a834e72b8e52e18746b927f34e4520487098e283a719c205e/cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285", size = 4239657 },
     { url = "https://files.pythonhosted.org/packages/46/b0/f4f7d0d0bcfbc8dd6296c1449be326d04217c57afb8b2594f017eed95533/cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417", size = 2758672 },
@@ -844,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "rapyuta-io"
-version = "2.2.2"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
@@ -855,14 +854,13 @@ dependencies = [
     { name = "six" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/51/c497160a29357ecbbb521bc3803b76867a833571109609334a5425ee27a7/rapyuta_io-2.2.2.tar.gz", hash = "sha256:2d569516b10baa83734a036223cb9599ad7a41a01021157b2e92450eb44a21c8", size = 52407 }
+sdist = { url = "https://files.pythonhosted.org/packages/20/c2/8e30f9ad4c0f2cf00ae1c3ca52422bbc0e1dcc549a6fbb7384edd786a2de/rapyuta_io-2.3.0.tar.gz", hash = "sha256:3f2446d73dc3ce094c2a0b9ac58af395fc98123a8c2fab607d21b105e9b64bd7", size = 53369 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/7b/9feb722161bbd9abebe6f7fbfa48c408023384b17b8b6c6b5caa62153c51/rapyuta_io-2.2.2-py3-none-any.whl", hash = "sha256:31faa0cfe150ef44fe21e730d35275ff81f0a268ca71b55b38bf8dfc68517b0c", size = 60873 },
+    { url = "https://files.pythonhosted.org/packages/0e/fa/1898606443cf7368d6ad01b0b6274830994a7da423aa40d3d2b5c61dd4ec/rapyuta_io-2.3.0-py3-none-any.whl", hash = "sha256:3755809acfc0554e919c6d593a3fc664c25be477ca8eb8e1bbfa822efca35413", size = 61954 },
 ]
 
 [[package]]
 name = "rapyuta-io-cli"
-version = "9.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core" },
@@ -935,7 +933,7 @@ requires-dist = [
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "pytz" },
     { name = "pyyaml", specifier = ">=5.4.1" },
-    { name = "rapyuta-io", specifier = ">=2.2.2" },
+    { name = "rapyuta-io", specifier = ">=2.3.0" },
     { name = "requests", specifier = ">=2.20.0" },
     { name = "semver", specifier = ">=3.0.0" },
     { name = "setuptools" },


### PR DESCRIPTION
### Description

### Testing
With `--async`
```
╭─ ~/Projects/python/rapyuta-robotics/rapyuta-io-cli on feat/exec-on-multiple-devices !2                     took 17s Py rapyuta-io-cli at 13:17:09
╰─❯ uv run rio device execute '.*' 'uname -a' --async
>>> 17098c40-5aec-42a7-bd4d-825bc72f4699: Success
Linux controller2 5.15.0-86-generic #96~20.04.1-Ubuntu SMP Thu Sep 21 13:23:37 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
>>> f1677d7d-07c7-4877-905b-ef4dfe56426a: Success
Linux nuc-sn-btws24200glv 6.5.0-1020-oem #21-Ubuntu SMP PREEMPT_DYNAMIC Wed Apr  3 14:54:32 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
>>> e7ac3b0a-bdf1-4c8a-a4aa-f38187831ebd: Success
Linux edge2 6.5.0-1020-oem #21-Ubuntu SMP PREEMPT_DYNAMIC Wed Apr  3 14:54:32 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```
Without `--async`
```
╭─ ~/Projects/python/rapyuta-robotics/rapyuta-io-cli on feat/exec-on-multiple-devices !2                     took 43s Py rapyuta-io-cli at 13:15:53
╰─❯ uv run rio device execute '.*' 'uname -a'        
>>> 17098c40-5aec-42a7-bd4d-825bc72f4699: Success
Linux controller2 5.15.0-86-generic #96~20.04.1-Ubuntu SMP Thu Sep 21 13:23:37 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
>>> e7ac3b0a-bdf1-4c8a-a4aa-f38187831ebd: Success
Linux edge2 6.5.0-1020-oem #21-Ubuntu SMP PREEMPT_DYNAMIC Wed Apr  3 14:54:32 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
>>> f1677d7d-07c7-4877-905b-ef4dfe56426a: Success
Linux nuc-sn-btws24200glv 6.5.0-1020-oem #21-Ubuntu SMP PREEMPT_DYNAMIC Wed Apr  3 14:54:32 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```
---
Fixes [AB#39696](https://dev.azure.com/rapyuta-robotics/3151e969-9eb7-4729-b4e8-8c659c416104/_workitems/edit/39696)