### PR TITLE
feat(package): supports hostPID for package

### DIFF
--- a/riocli/apply/manifests/package.yaml
+++ b/riocli/apply/manifests/package.yaml
@@ -337,6 +337,7 @@ metadata:
     app: test
 spec:
   runtime: device # Options: [device, cloud(default)]
+  hostPID: True   # Optional: Enable hostpid to give the host process namespace access to executables
   device:
     arch: amd64 # Options: [arm32v7, arm64v8, amd64]
     restart: always # Options: [always, never, onfailure]

--- a/riocli/jsonschema/schemas/package-schema.yaml
+++ b/riocli/jsonschema/schemas/package-schema.yaml
@@ -78,6 +78,8 @@ definitions:
                 type: array
                 items:
                   "$ref": "#/definitions/deviceROSBagJobSpec"
+              hostPID:
+                type: boolean
 
           - properties:
               runtime:


### PR DESCRIPTION
This PR modifies the host pid namespace item and this prop uses for schema validation.