### PR TITLE
🔧 Chore: Report device command visible

### DIFF
--- a/riocli/device/report.py
+++ b/riocli/device/report.py
@@ -25,7 +25,6 @@ from riocli.utils.spinner import with_spinner
     cls=HelpColorsCommand,
     help_headers_color=Colors.YELLOW,
     help_options_color=Colors.GREEN,
-    hidden=True,
 )
 @click.option(
     "--force", "-f", "--silent", "force", is_flag=True, help="Skip confirmation"
@@ -57,7 +56,7 @@ def report_device(
     spinner=None,
 ) -> None:
     """
-    Uploads device debug logs and optionally generates a shareable URL with an expiry time.
+    Uploads device debug logs.
 
     Usage Examples:
 


### PR DESCRIPTION
This pull request includes a small change to the `riocli/device/report.py` file. The change removes the `hidden=True` attribute from the command configuration to make the command visible in the help output.