### PR TITLE
feat(apply): add support for multiple interfaces in get_intf_ip filter

### DIFF
--- a/riocli/apply/util.py
+++ b/riocli/apply/util.py
@@ -28,7 +28,7 @@ from ansible.plugins.filter.urlsplit import FilterModule as URLSplitFilterModule
 from ansible.plugins.filter.mathstuff import FilterModule as MathFilterModule
 from ansible.plugins.filter.encryption import FilterModule as EncryptionFilterModule
 
-from riocli.apply.filters import FILTERS
+from riocli.apply.filters import get_interface_ip, getenv
 from riocli.constants import Colors
 from riocli.deployment.model import Deployment
 from riocli.device.model import Device
@@ -54,6 +54,11 @@ KIND_TO_CLASS = {
     "deployment": Deployment,
     "managedservice": ManagedService,
     "usergroup": UserGroup,
+}
+
+FILTERS = {
+    "getenv": getenv,
+    "get_intf_ip": get_interface_ip,
 }
 
 

--- a/riocli/device/util.py
+++ b/riocli/device/util.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import functools
+from functools import wraps, lru_cache
 import json
 import re
 import time
@@ -37,7 +37,7 @@ from riocli.v2client.util import handle_server_errors
 
 
 def name_to_guid(f: typing.Callable) -> typing.Callable:
-    @functools.wraps(f)
+    @wraps(f)
     def decorated(**kwargs: typing.Any):
         try:
             client = new_client()
@@ -118,6 +118,7 @@ def get_device_name(client: Client, guid: str) -> str:
     return device.name
 
 
+@lru_cache
 def find_device_guid(client: Client, name: str) -> str:
     devices = client.get_all_devices(device_name=name)
     for device in devices:
@@ -136,7 +137,7 @@ def find_device_by_name(client: Client, name: str) -> Device:
 
 
 def name_to_request_id(f: typing.Callable) -> typing.Callable:
-    @functools.wraps(f)
+    @wraps(f)
     def decorated(**kwargs):
         try:
             client = new_client()


### PR DESCRIPTION
The `get_intf_ip` filter now supports a comma-separated list of network interfaces. It returns the first IP address found among the specified interfaces.

Additionally, the filter is optimized to cache results, preventing repeated network calls and ensuring better performance when used multiple times in a workflow.