### PR TITLE
feat(vpn): support tailscale's fast user switching

### DIFF
--- a/riocli/vpn/connect.py
+++ b/riocli/vpn/connect.py
@@ -35,7 +35,7 @@ from riocli.vpn.util import (
 )
 
 _TAILSCALE_CMD_FORMAT = (
-    "tailscale up --auth-key={} --login-server={} --reset --force-reauth "
+    "tailscale login --auth-key={} --login-server={} --nickname rio "
     "--accept-routes --accept-dns --advertise-tags={} --timeout=30s"
 )
 


### PR DESCRIPTION
The `rio vpn connect` command previously forced authentication on each use, causing other Tailscale accounts to be lost.

Now, the command uses `tailscale login` with the `rio` nickname, retaining other Tailscale accounts while simplifying user switching.