### PR TITLE
fix(cli): returns success in case deployment, package, secret, route, device, disk, network not found while deleting

### DIFF
--- a/riocli/deployment/delete.py
+++ b/riocli/deployment/delete.py
@@ -106,9 +106,9 @@ def delete_deployment(
         raise SystemExit(1) from e
 
     if not deployments:
-        spinner.text = click.style("Deployment(s) not found", Colors.RED)
-        spinner.red.fail(Symbols.ERROR)
-        raise SystemExit(1)
+        spinner.text = "Deployment(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
 
     with spinner.hidden():
         print_deployments_for_confirmation(deployments)

--- a/riocli/device/delete.py
+++ b/riocli/device/delete.py
@@ -100,9 +100,9 @@ def delete_device(
         raise SystemExit(1) from e
 
     if not devices:
-        spinner.text = click.style("Device(s) not found", Colors.RED)
-        spinner.red.fail(Symbols.ERROR)
-        raise SystemExit(1)
+        spinner.text = "Device(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
 
     headers = ["Name", "Device ID", "Status"]
     data = [[d.name, d.uuid, d.status] for d in devices]

--- a/riocli/disk/delete.py
+++ b/riocli/disk/delete.py
@@ -105,9 +105,9 @@ def delete_disk(
         raise SystemExit(1) from e
 
     if not disks:
-        spinner.text = click.style("Disk(s) not found", Colors.RED)
-        spinner.red.fail(Symbols.ERROR)
-        raise SystemExit(1)
+        spinner.text = "Disk(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
 
     with spinner.hidden():
         display_disk_list(disks)

--- a/riocli/network/delete.py
+++ b/riocli/network/delete.py
@@ -97,9 +97,9 @@ def delete_network(
         raise SystemExit(1) from e
 
     if not networks:
-        spinner.text = click.style("Network(s) not found", Colors.RED)
-        spinner.red.fail(Symbols.ERROR)
-        raise SystemExit(1)
+        spinner.text = "Network(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
 
     with spinner.hidden():
         print_networks_for_confirmation(networks)

--- a/riocli/package/delete.py
+++ b/riocli/package/delete.py
@@ -89,9 +89,9 @@ def delete_package(
         raise SystemExit(1) from e
 
     if not packages:
-        spinner.text = click.style("Package(s) not found", Colors.RED)
-        spinner.red.fail(Symbols.ERROR)
-        raise SystemExit(1)
+        spinner.text = "Package(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
 
     with spinner.hidden():
         print_packages_for_confirmation(packages)

--- a/riocli/secret/delete.py
+++ b/riocli/secret/delete.py
@@ -97,19 +97,19 @@ def delete_secret(
         return
 
     try:
-        routes = fetch_secrets(client, secret_name_or_regex, delete_all)
+        secrets = fetch_secrets(client, secret_name_or_regex, delete_all)
     except Exception as e:
         spinner.text = click.style("Failed to delete secret(s): {}".format(e), Colors.RED)
         spinner.red.fail(Symbols.ERROR)
         raise SystemExit(1) from e
 
-    if not routes:
-        spinner.text = click.style("Secret(s) not found", Colors.RED)
-        spinner.red.fail(Symbols.ERROR)
-        raise SystemExit(1)
+    if not secrets:
+        spinner.text = "Secret(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
 
     with spinner.hidden():
-        print_secrets_for_confirmation(routes)
+        print_secrets_for_confirmation(secrets)
 
     spinner.write("")
 
@@ -121,7 +121,7 @@ def delete_secret(
     try:
         f = functools.partial(_apply_delete, client)
         result = apply_func_with_result(
-            f=f, items=routes, workers=workers, key=lambda x: x[0]
+            f=f, items=secrets, workers=workers, key=lambda x: x[0]
         )
 
         data, statuses = [], []
@@ -136,7 +136,7 @@ def delete_secret(
         with spinner.hidden():
             tabulate_data(data, headers=["Name", "Status"])
 
-        # When no route is deleted, raise an exception.
+        # When no secret is deleted, raise an exception.
         if not any(statuses):
             spinner.write("")
             spinner.text = click.style("Failed to delete secret(s).", Colors.RED)

--- a/riocli/static_route/delete.py
+++ b/riocli/static_route/delete.py
@@ -106,9 +106,9 @@ def delete_static_route(
         raise SystemExit(1) from e
 
     if not routes:
-        spinner.text = click.style("Static route(s) not found", Colors.RED)
-        spinner.red.fail(Symbols.ERROR)
-        raise SystemExit(1)
+        spinner.text = "Static route(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
 
     with spinner.hidden():
         print_routes_for_confirmation(routes)


### PR DESCRIPTION
Issue: The CLI returns exit code 1 when resources are not found for --all or no regex or name match.
This PR fixes the issues by returning exit code 0 if resource not found i.e no resource to delete