### PR TITLE
Fix: clean dockercache details if disabled

### DIFF
--- a/riocli/project/features/dockercache.py
+++ b/riocli/project/features/dockercache.py
@@ -85,13 +85,16 @@ def dockercache(
         spinner.red.fail(Symbols.ERROR)
         raise SystemExit(1) from e
 
-    project["spec"]["features"]["dockerCache"] = {
-        "enabled": enable,
-        "proxyDevice": proxy_device,
-        "proxyInterface": proxy_interface,
-        "registryURL": registry_url,
-        "registrySecret": registry_secret,
-    }
+    if enable:
+        project["spec"]["features"]["dockerCache"] = {
+            "enabled": enable,
+            "proxyDevice": proxy_device,
+            "proxyInterface": proxy_interface,
+            "registryURL": registry_url,
+            "registrySecret": registry_secret,
+        }
+    else:
+        project["spec"]["features"]["dockerCache"] = {"enabled": enable}
 
     is_enabled = project["spec"]["features"]["dockerCache"].get("enabled", False)
 


### PR DESCRIPTION
This pull request includes a modification to the `dockercache` function in the `riocli/project/features/dockercache.py` file. The change ensures that the `dockerCache` feature is correctly configured based on the `enable` parameter.

Changes in `dockercache` function:

* Added a conditional check to set the `dockerCache` feature configuration with additional parameters only if the `enable` flag is true. If `enable` is false, it sets the `dockerCache` feature configuration with only the `enabled` parameter.

Task:
Resolved [AB#48691](https://dev.azure.com/rapyuta-robotics/3151e969-9eb7-4729-b4e8-8c659c416104/_workitems/edit/48691)