### PR TITLE
feat: add get_suffix method to set suffix in values

### DIFF
--- a/riocli/apply/filters.py
+++ b/riocli/apply/filters.py
@@ -19,7 +19,7 @@ from functools import lru_cache
 import os
 from typing import Dict, List
 
-from riocli.config import new_client
+from riocli.config import new_client, Configuration
 from riocli.device.util import find_device_guid
 
 
@@ -85,3 +85,17 @@ def get_device_ip_interfaces(device_name: str) -> Dict[str, List[str]]:
     device.refresh()
 
     return device.ip_interfaces
+
+def get_suffix(suffix: str) -> str:
+    """Get the name of the project.
+
+    Usage:
+        "suffix" : {{ "suffix_value" | get_suffix }}
+
+    Returns:
+        Value of the suffix and default value is the project name from the configuration file.
+    """
+    if suffix:
+        return suffix
+    config = Configuration()
+    return config.data.get("project_name")

--- a/riocli/apply/util.py
+++ b/riocli/apply/util.py
@@ -28,7 +28,7 @@ from ansible.plugins.filter.urlsplit import FilterModule as URLSplitFilterModule
 from ansible.plugins.filter.mathstuff import FilterModule as MathFilterModule
 from ansible.plugins.filter.encryption import FilterModule as EncryptionFilterModule
 
-from riocli.apply.filters import get_interface_ip, getenv
+from riocli.apply.filters import get_interface_ip, getenv, get_suffix
 from riocli.constants import Colors
 from riocli.deployment.model import Deployment
 from riocli.device.model import Device
@@ -59,6 +59,7 @@ KIND_TO_CLASS = {
 FILTERS = {
     "getenv": getenv,
     "get_intf_ip": get_interface_ip,
+    "get_suffix": get_suffix
 }
 
 


### PR DESCRIPTION
This pull request includes changes to the `riocli` package, specifically adding a new utility function and updating imports to accommodate this addition.

The most important changes include:

### New Utility Function:

* [`riocli/apply/filters.py`](diffhunk://#diff-b4c0f2dd28184247392940a63f2f7fa79d04338924d203b4b08529a115af1b6dR88-R101): Added a new function `get_suffix` to return suffix (if provided) or default suffix i.e., project name where service will be deployed.

Resolves [AB#49716](https://dev.azure.com/rapyuta-robotics/3151e969-9eb7-4729-b4e8-8c659c416104/_workitems/edit/49716)