### PR TITLE
feat(apply): add context in the output for apply-family of commands

### DIFF
--- a/riocli/apply/filters.py
+++ b/riocli/apply/filters.py
@@ -71,6 +71,7 @@ def get_interface_ip(device_name: str, interface: str) -> str:
 
     raise Exception(f'interface "{interface}" not found on device "{device_name}"')
 
+
 @lru_cache
 def get_device_ip_interfaces(device_name: str) -> Dict[str, List[str]]:
     client = new_client(with_project=True)

--- a/riocli/apply/parse.py
+++ b/riocli/apply/parse.py
@@ -45,12 +45,18 @@ class Applier(object):
     DEFAULT_MAX_WORKERS = 6
     DELETE_POLICY_LABEL = "rapyuta.io/deletionPolicy"
 
-    def __init__(self, files: typing.List, values: typing.List, secrets: typing.List):
+    def __init__(
+        self,
+        files: typing.List,
+        values: typing.List,
+        secrets: typing.List,
+        config: Configuration,
+    ):
         self.files = {}
         self.objects = {}
         self.resolved_objects = {}
         self.input_file_paths = files
-        self.config = Configuration()
+        self.config = config
         self.graph = TopologicalSorter()
         self.environment = init_jinja_environment()
         self.diagram = Graphviz(direction="LR", format="svg")

--- a/riocli/apply/template.py
+++ b/riocli/apply/template.py
@@ -18,6 +18,7 @@ from click_help_colors import HelpColorsCommand
 
 from riocli.apply.parse import Applier
 from riocli.apply.util import process_files_values_secrets
+from riocli.config import get_config_from_context
 from riocli.constants import Colors
 
 
@@ -44,7 +45,9 @@ from riocli.constants import Colors
     "expects sops to be authorized for decoding files on this computer",
 )
 @click.argument("files", nargs=-1)
+@click.pass_context
 def template(
+    ctx: click.Context,
     values: typing.Tuple[str],
     secrets: typing.Tuple[str],
     files: typing.Tuple[str],
@@ -82,5 +85,6 @@ def template(
         click.secho("No files specified", fg=Colors.RED)
         raise SystemExit(1)
 
-    applier = Applier(glob_files, abs_values, abs_secrets)
+    config = get_config_from_context(ctx)
+    applier = Applier(glob_files, abs_values, abs_secrets, config)
     applier.print_resolved_manifests()

--- a/riocli/apply/util.py
+++ b/riocli/apply/util.py
@@ -29,7 +29,9 @@ from ansible.plugins.filter.mathstuff import FilterModule as MathFilterModule
 from ansible.plugins.filter.encryption import FilterModule as EncryptionFilterModule
 
 from riocli.apply.filters import get_interface_ip, getenv
+from riocli.config import get_config_from_context
 from riocli.constants import Colors
+from riocli.constants.symbols import Symbols
 from riocli.deployment.model import Deployment
 from riocli.device.model import Device
 from riocli.disk.model import Disk
@@ -177,3 +179,21 @@ def init_jinja_environment():
         environment.filters[name] = func
 
     return environment
+
+
+def print_context(ctx: click.Context):
+    config = get_config_from_context(ctx)
+
+    org_guid = config.organization_guid
+    org_name = config.data.get("organization_name")
+    project_guid = config.project_guid
+    project_name = config.data.get("project_name")
+
+    click.secho(
+        "{} Organization: {} ({})".format(Symbols.INFO, org_name, org_guid),
+        fg=Colors.YELLOW,
+    )
+    click.secho(
+        "{} Project: {} ({})".format(Symbols.INFO, project_name, project_guid),
+        fg=Colors.YELLOW,
+    )


### PR DESCRIPTION
Resolves [AB#59533](https://dev.azure.com/rapyuta-robotics/3151e969-9eb7-4729-b4e8-8c659c416104/_workitems/edit/59533)
# Apply Example
```
ℹ️ Organization: Rapyuta (org-wvnwcmvfkbajavjetttcutga)
ℹ️ Project: ankit (project-cp3fv3ojkeas73fm3oi0)a
--------------------------------------------------------------------------------------- Files Processed ----------------------------------------------------------------------------------------
/home/ankit/.local/src/work/scratch/docker-cache/project.yaml
--------------------------------------------------------------------------------------- Parsed Resources ---------------------------------------------------------------------------------------
Kind     Name
-------  -------------
Project  green-field-1
Project  green-field-2
-------------------------------------------------------------------------------------- Applying Manifests --------------------------------------------------------------------------------------
>> ⏳ Applying project:green-field-1...                                                                                                                [2025-04-22T19:51:25.864137]
>> ✅ Created project:green-field-1                                                                                                                    [2025-04-22T19:51:25.864223]
>> ⏳ Applying project:green-field-2...                                                                                                                [2025-04-22T19:51:25.870370]
>> ✅ Created project:green-field-2                                                                                                                    [2025-04-22T19:51:25.870429]
✅ Apply successful. (0:00:00.02)
at 19:51:25 ☸  io-stag ~/.l/s/work/scratch/docker-cache via 🐍 v3.10.14 (rapyuta-io-cli)
```

# Chart Apply Example
```
<I> rio chart apply -v ./values.yaml -f gostproxy -d
Downloading gostproxy:1.0.0 chart in /tmp/rio-chart-gostproxy-cyhialfq
ℹ️  Organization: Rapyuta (org-wvnwcmvfkbajavjetttcutga)
ℹ️  Project: ankit (project-cp3fv3ojkeas73fm3oi0)
--------------------------------------------------------------------------------------- Files Processed ----------------------------------------------------------------------------------------
/tmp/rio-chart-gostproxy-cyhialfq/gostproxy/templates/deployment.yaml
/tmp/rio-chart-gostproxy-cyhialfq/gostproxy/templates/package.yaml
/tmp/rio-chart-gostproxy-cyhialfq/gostproxy/templates/static-route.yaml
--------------------------------------------------------------------------------------- Parsed Resources ---------------------------------------------------------------------------------------
Kind         Name
-----------  -------------
Deployment   generic_proxy
Package      gostproxy
Staticroute  nginx-ankit
-------------------------------------------------------------------------------------- Applying Manifests --------------------------------------------------------------------------------------
>> ⏳ Applying staticroute:nginx-ankit...                                                                                                              [2025-04-22T19:52:20.985863]
>> ✅ Created staticroute:nginx-ankit                                                                                                                  [2025-04-22T19:52:21.010658]
>> ⏳ Applying package:gostproxy...                                                                                                                    [2025-04-22T19:52:21.035992]
>> ✅ Created package:gostproxy                                                                                                                        [2025-04-22T19:52:21.036031]
>> ⏳ Applying deployment:generic_proxy...                                                                                                             [2025-04-22T19:52:21.061655]
>> ✅ Created deployment:generic_proxy                                                                                                                 [2025-04-22T19:52:21.061689]
✅ Apply successful. (0:00:00.09)
```