### PR TITLE
fix(project): fixes the list and inspect project functionality when no organization selected

### DIFF
--- a/riocli/project/list.py
+++ b/riocli/project/list.py
@@ -19,7 +19,7 @@ from click_help_colors import HelpColorsCommand
 from munch import unmunchify
 
 from riocli.config import new_v2_client
-from riocli.constants import Colors, Symbols
+from riocli.constants import Colors
 from riocli.organization.util import name_to_guid as name_to_organization_guid
 from riocli.utils import tabulate_data
 
@@ -74,13 +74,6 @@ def list_projects(
     """
     # If organization is not passed in the options, use
     organization_guid = organization_guid or ctx.obj.data.get("organization_id")
-    if organization_guid is None:
-        err_msg = (
-            "Organization not selected. Please set an organization with "
-            "`rio organization select ORGANIZATION_NAME` or pass the --organization option."
-        )
-        click.secho("{} {}".format(Symbols.ERROR, err_msg), fg=Colors.RED)
-        raise SystemExit(1)
 
     query = {"labelSelector": labels}
 

--- a/riocli/v2client/client.py
+++ b/riocli/v2client/client.py
@@ -71,11 +71,11 @@ class Client(object):
         query: Optional[dict] = None,
     ) -> Munch:
         """
-        List all projects in an organization
+        List all projects in an organization or where user have the access to in all organizations.
         """
 
         url = "{}/v2/projects/".format(self._host)
-        headers = self._get_auth_header(with_project=False)
+        headers = self._get_auth_header(with_project=False, with_organization=False)
 
         params = {}
 
@@ -96,7 +96,7 @@ class Client(object):
         Get a project by its GUID
         """
         url = "{}/v2/projects/{}/".format(self._host, project_guid)
-        headers = self._get_auth_header()
+        headers = self._get_auth_header(with_organization=False)
         response = RestClient(url).method(HttpMethod.GET).headers(headers).execute()
 
         handle_server_errors(response)


### PR DESCRIPTION
This PR , fixes the list and inspect project functionality when no organization selected. So for list project without organization selected it will return all projects from all organization where user belongs to. Same for inspect as well.