### PR TITLE
fix: run commands on devices in background

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "python-magic>=0.4.27",
     "pytz",
     "pyyaml>=5.4.1",
-    "rapyuta_io>=2.3.1",
+    "rapyuta-io @ git+https://github.com/rapyuta-robotics/rapyuta-io-sdk@5fb64de1603fa7d1c6e224dfd4ee0a0dbd2a5cfc",
     "requests>=2.20.0",
     "semver>=3.0.0",
     "setuptools",

--- a/riocli/device/execute.py
+++ b/riocli/device/execute.py
@@ -37,6 +37,14 @@ from shlex import join
     default=False,
     help="Run the command asynchronously.",
 )
+@click.option(
+    "--bg",
+    "bg",
+    default=False,
+    is_flag=True,
+    help="Run command in background.",
+    hidden=True,
+)
 @click.argument("device-name-or-regex", type=str)
 @click.argument("command", nargs=-1)
 def execute_command(
@@ -45,6 +53,7 @@ def execute_command(
     timeout: int,
     shell: str,
     run_async: bool,
+    bg:bool,
     command: typing.List[str],
 ) -> None:
     """Execute commands on one or more devices.
@@ -96,7 +105,7 @@ def execute_command(
     try:
         result = client.execute_command(
             device_ids=device_guids,
-            command=Command(cmd, shell=shell, bg=run_async, runas=user, timeout=timeout),
+            command=Command(cmd, shell=shell, bg=bg, run_async=run_async, runas=user, timeout=timeout),
             timeout=timeout,
         )
         for device_guid in result:

--- a/uv.lock
+++ b/uv.lock
@@ -843,8 +843,8 @@ wheels = [
 
 [[package]]
 name = "rapyuta-io"
-version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
+version = "1.17.1"
+source = { git = "https://github.com/rapyuta-robotics/rapyuta-io-sdk?rev=5fb64de1603fa7d1c6e224dfd4ee0a0dbd2a5cfc#5fb64de1603fa7d1c6e224dfd4ee0a0dbd2a5cfc" }
 dependencies = [
     { name = "python-dateutil" },
     { name = "pytz" },
@@ -853,10 +853,6 @@ dependencies = [
     { name = "setuptools" },
     { name = "six" },
     { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/57/4535a1073968f8c8dedc6aedb997c1c2b0ff784592e553a4472a392acf88/rapyuta_io-2.3.1.tar.gz", hash = "sha256:25961fcda9cf3138eb36a1693c56a0513b864a294fc97bb9ad261ef58f40cb66", size = 53479, upload-time = "2025-04-09T12:13:28.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/f8/eca842d592312a3a190acd0794f960d4dfa93a5ad320768d4c9c04ec2293/rapyuta_io-2.3.1-py3-none-any.whl", hash = "sha256:5eb1a676c845f30cd822f0a6e345c5fdbb7fea28c3ff5a3858e1169a11daeab9", size = 62063, upload-time = "2025-04-09T12:13:26.841Z" },
 ]
 
 [[package]]
@@ -933,7 +929,7 @@ requires-dist = [
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "pytz" },
     { name = "pyyaml", specifier = ">=5.4.1" },
-    { name = "rapyuta-io", specifier = ">=2.3.1" },
+    { name = "rapyuta-io", git = "https://github.com/rapyuta-robotics/rapyuta-io-sdk?rev=5fb64de1603fa7d1c6e224dfd4ee0a0dbd2a5cfc" },
     { name = "requests", specifier = ">=2.20.0" },
     { name = "semver", specifier = ">=3.0.0" },
     { name = "setuptools" },


### PR DESCRIPTION
## 🚀 Building the CLI AppImage Locally

Follow these steps to build the CLI AppImage on your local machine:

### 1. Prepare the Environment

- Switch to the appropriate branch.
- Install dependencies by running:
```bash
uv sync
```

### 2. Download AppImages

- Download the required AppImage files.
- Extract them into the `scripts/` directory.
    * [appimagetool.tar.gz](https://github.com/user-attachments/files/20198119/appimagetool.tar.gz)
    * [python_appimage.tar.gz](https://github.com/user-attachments/files/20198126/python_appimage.tar.gz)

### 3. Run the Build

You have two options to continue:

#### Option A: - Open the script located at:

  ```bash
  ./scripts/build-rio-appimage.sh
  ```

- **Comment out lines 1–13**. These lines are intended for the AppImage CI pipeline and fetch the AppImage from MinIO.

#### Option B: Run the Required Commands Manually

```bash
chmod +x scripts/*.AppImage
uv build
cp dist/rapyuta_io_cli-*.whl scripts/

# If you are using Ubuntu or Debian
sudo apt-get update
sudo apt-get install fuse libfuse2

cd scripts
./python3.11.1-cp311-cp311-manylinux_2_24_x86_64.AppImage --appimage-extract
./squashfs-root/AppRun -m pip install --upgrade pip
./squashfs-root/AppRun -m pip install rapyuta_io_cli-*.whl

# Making AppRun
sed -i -e 's|/opt/python3.11/bin/python3.11|/usr/bin/rio|g' squashfs-root/AppRun

# Making rio.desktop
mv squashfs-root/usr/share/applications/python3.11.1.desktop squashfs-root/usr/share/applications/rio.desktop
sed -i -e 's|^Name=.*|Name=rio|g' squashfs-root/usr/share/applications/rio.desktop
sed -i -e 's|^Exec=.*|Exec=rio|g' squashfs-root/usr/share/applications/rio.desktop
sed -i -e 's|^Comment=.*|Comment=A rapyuta.io CLI|g' squashfs-root/usr/share/applications/rio.desktop
rm squashfs-root/python3.11.1.desktop
cp squashfs-root/usr/share/applications/rio.desktop squashfs-root/

./appimagetool-x86_64 -n squashfs-root/
```

Now, your appimage build is done inside scripts folder.

https://github.com/user-attachments/assets/aeb9ea9d-95b7-4ede-84ba-94af9206fb4f



resolves https://github.com/rapyuta-robotics/rapyuta_io/issues/821
