### PR TITLE
fix: remove deprecated pkg_resources module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "argparse>=1.4.0",
     "click-completion>=0.5.2",
     "click-help-colors>=0.9.1",
-    "click-plugins>=1.1.1",
     "click-repl>=0.2.0",
     "click-spinner>=0.1.10",
     "click~=8.0.1",

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -21,8 +21,6 @@ import click
 import rapyuta_io.version
 from click import Context
 from click_help_colors import HelpColorsGroup
-from click_plugins import with_plugins
-from pkg_resources import iter_entry_points
 
 from riocli.apply import apply, delete
 from riocli.apply.explain import list_examples, explain
@@ -58,7 +56,6 @@ from riocli.utils import (
 from riocli.vpn import vpn
 
 
-@with_plugins(iter_entry_points("riocli.plugins"))
 @click.group(
     invoke_without_command=False,
     cls=HelpColorsGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -291,18 +291,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click-plugins"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/1d/45434f64ed749540af821fd7e42b8e4d23ac04b1eda7c26613288d6cd8a8/click-plugins-1.1.1.tar.gz", hash = "sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b", size = 8164, upload-time = "2019-04-04T04:27:04.82Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/da/824b92d9942f4e472702488857914bdd50f73021efea15b4cad9aca8ecef/click_plugins-1.1.1-py2.py3-none-any.whl", hash = "sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8", size = 7497, upload-time = "2019-04-04T04:27:03.36Z" },
-]
-
-[[package]]
 name = "click-repl"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -873,7 +861,6 @@ dependencies = [
     { name = "click" },
     { name = "click-completion" },
     { name = "click-help-colors" },
-    { name = "click-plugins" },
     { name = "click-repl" },
     { name = "click-spinner" },
     { name = "dictdiffer" },
@@ -919,7 +906,6 @@ requires-dist = [
     { name = "click", specifier = "~=8.0.1" },
     { name = "click-completion", specifier = ">=0.5.2" },
     { name = "click-help-colors", specifier = ">=0.9.1" },
-    { name = "click-plugins", specifier = ">=1.1.1" },
     { name = "click-repl", specifier = ">=0.2.0" },
     { name = "click-spinner", specifier = ">=0.1.10" },
     { name = "dictdiffer", specifier = ">=0.9.0" },


### PR DESCRIPTION
Resolves rapyuta-robotics/rapyuta_io#887

## Testing

I used this script to test the changes across supported Python versions.

``` sh
#!/usr/bin/env bash

set -o errexit
set -o errtrace
set -o pipefail

PYTHON_VERSIONS=(python3.8 python3.9 python3.10 python3.11 python3.12 python3.13)

printf "Running rio against all supported Python versions...\n\n"

for each in ${PYTHON_VERSIONS[@]}
do
	printf "${each}...\n"
	printf "\tInitializing environment...\n"
	uv venv --python "$each" "$each" > /dev/null 2>&1

	printf "\tInstalling CLI...\n"
	pushd "$each"
	source bin/activate
	uv pip install ~/.local/src/work/rapyuta-io-cli/dist/rapyuta_io_cli-9.5.0-py3-none-any.whl > /dev/null 2>&1

	printf "\tRunning CLI...\n"
	rio --help > /dev/null

	deactivate
	popd
	printf "\n"
done
```


Output against devel.
``` shellsession
$ ./run-against-python.sh
Running rio against all supported Python versions...

python3.8...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.8 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.9...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.9 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
/home/ankit/.local/src/work/rapyuta-io-cli/ignore/test/python3.9/lib/python3.9/site-packages/riocli/bootstrap.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.10...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.10 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
/home/ankit/.local/src/work/rapyuta-io-cli/ignore/test/python3.10/lib/python3.10/site-packages/riocli/bootstrap.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.11...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.11 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
/home/ankit/.local/src/work/rapyuta-io-cli/ignore/test/python3.11/lib/python3.11/site-packages/riocli/bootstrap.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.12...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.12 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
/home/ankit/.local/src/work/rapyuta-io-cli/ignore/test/python3.12/lib/python3.12/site-packages/riocli/bootstrap.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.13...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.13 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
/home/ankit/.local/src/work/rapyuta-io-cli/ignore/test/python3.13/lib/python3.13/site-packages/riocli/bootstrap.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
~/.local/src/work/rapyuta-io-cli/ignore/test
```

Output with this Patch.
``` shellsession
<I> ./run-against-python.sh
Running rio against all supported Python versions...

python3.8...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.8 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.9...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.9 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.10...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.10 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.11...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.11 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.12...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.12 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test

python3.13...
        Initializing environment...
        Installing CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test/python3.13 ~/.local/src/work/rapyuta-io-cli/ignore/test
        Running CLI...
~/.local/src/work/rapyuta-io-cli/ignore/test
```