### PR TITLE
fix(apply): support both APIVersion strings

### DIFF
--- a/riocli/jsonschema/schemas/deployment-schema.yaml
+++ b/riocli/jsonschema/schemas/deployment-schema.yaml
@@ -7,8 +7,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
-        default: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Deployment
         default: Deployment
@@ -193,6 +195,7 @@ definitions:
                     properties:
                       enabled:
                         type: boolean
+                        default: false
                     required:
                       - enabled
                   params:
@@ -200,12 +203,15 @@ definitions:
                     properties:
                       enabled:
                         type: boolean
+                        default: false
                       trees:
                         type: array
                         items:
                           type: string
                       disableSync:
                         type: boolean
+                    required:
+                      - enabled
               envArgs:
                 type: array
                 items:
@@ -336,5 +342,3 @@ definitions:
         type: string
       guid:
         type: string
-
-

--- a/riocli/jsonschema/schemas/device-schema.yaml
+++ b/riocli/jsonschema/schemas/device-schema.yaml
@@ -24,7 +24,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Device
       metadata:

--- a/riocli/jsonschema/schemas/disk-schema.yaml
+++ b/riocli/jsonschema/schemas/disk-schema.yaml
@@ -7,8 +7,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
-        default: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Disk
         default: Disk

--- a/riocli/jsonschema/schemas/managedservice-schema.yaml
+++ b/riocli/jsonschema/schemas/managedservice-schema.yaml
@@ -7,8 +7,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
-        default: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: ManagedService
         default: ManagedService

--- a/riocli/jsonschema/schemas/network-schema.yaml
+++ b/riocli/jsonschema/schemas/network-schema.yaml
@@ -7,7 +7,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Network
       metadata:

--- a/riocli/jsonschema/schemas/organization-schema.yaml
+++ b/riocli/jsonschema/schemas/organization-schema.yaml
@@ -8,8 +8,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: api.rapyuta.io/v2
         default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Organization
       metadata:

--- a/riocli/jsonschema/schemas/package-schema.yaml
+++ b/riocli/jsonschema/schemas/package-schema.yaml
@@ -7,8 +7,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
-        default: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Package
         default: Package

--- a/riocli/jsonschema/schemas/project-schema.yaml
+++ b/riocli/jsonschema/schemas/project-schema.yaml
@@ -8,8 +8,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: api.rapyuta.io/v2
         default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Project
       metadata:

--- a/riocli/jsonschema/schemas/secret-schema.yaml
+++ b/riocli/jsonschema/schemas/secret-schema.yaml
@@ -7,8 +7,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
-        default: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: Secret
       metadata:

--- a/riocli/jsonschema/schemas/static_route-schema.yaml
+++ b/riocli/jsonschema/schemas/static_route-schema.yaml
@@ -8,8 +8,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: apiextensions.rapyuta.io/v1
-        default: apiextensions.rapyuta.io/v1
+        default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: StaticRoute
       metadata:

--- a/riocli/jsonschema/schemas/usergroup-schema.yaml
+++ b/riocli/jsonschema/schemas/usergroup-schema.yaml
@@ -8,8 +8,10 @@ definitions:
     type: object
     properties:
       apiVersion:
-        const: api.rapyuta.io/v2
         default: api.rapyuta.io/v2
+        oneOf:
+          - const: apiextensions.rapyuta.io/v1
+          - const: api.rapyuta.io/v2
       kind:
         const: UserGroup
       metadata:


### PR DESCRIPTION
Previously, the manifests used the "apiextensions.rapyuta.io/v1" string. The v2
APIs now  return the "api.rapyuta.io/v2" string. This commit allows both strings
in all the resources.

Additionally, it adds the default value in the feature.{param,vpn}.enabled field
to allow manifests downloaded from inspect to work.

Resolves rapyuta-robotics/rapyuta_io#865