### PR TITLE
✨ feat(hwil): add X-Email-ID header in HWIL requests

### DIFF
--- a/riocli/config/config.py
+++ b/riocli/config/config.py
@@ -128,7 +128,7 @@ class Configuration(object):
 
         token = self.data.get("hwil_auth_token", None)
 
-        return HwilClient(auth_token=token)
+        return HwilClient(auth_token=token, email_id=self.data.get("email_id"))
 
     def get_auth_header(self: Configuration) -> dict:
         if not ("auth_token" in self.data and "project_id" in self.data):

--- a/riocli/hwil/login.py
+++ b/riocli/hwil/login.py
@@ -90,7 +90,7 @@ def validate_and_set_hwil_token(
         os.environ["RIO_CONFIG"] = ctx.obj.filepath
 
     token = b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
-    client = HwilClient(auth_token=token)
+    client = HwilClient(auth_token=token, email_id=ctx.obj.data.get("email_id"))
 
     try:
         client.list_devices()

--- a/riocli/hwilclient/client.py
+++ b/riocli/hwilclient/client.py
@@ -79,8 +79,9 @@ class Client(object):
         },
     }
 
-    def __init__(self, auth_token: str):
+    def __init__(self, auth_token: str, email_id: str = None):
         self._token = auth_token
+        self._email_id = email_id
         self._host = self.HWIL_URL
 
     def create_device(
@@ -236,4 +237,9 @@ class Client(object):
         return munchify(data)
 
     def _get_auth_header(self: Client) -> dict:
-        return dict(Authorization=f"Basic {self._token}")
+        header = dict(Authorization=f"Basic {self._token}")
+
+        if self._email_id is not None:
+            header["X-Email-ID"] = self._email_id
+
+        return header


### PR DESCRIPTION
This commit adds X-Email-ID header to all the HWIL requests. If the `email_id` field is not present, then it will skip the header.

## Testing

Traefik Logs

```
{
  "ClientAddr": "103.163.65.90:38744",
  "ClientHost": "103.163.65.90",
  "ClientPort": "38744",
  "ClientUsername": "-",
  "DownstreamContentSize": 23403,
  "DownstreamStatus": 200,
  "Duration": 566382391,
  "OriginContentSize": 23403,
  "OriginDuration": 566310691,
  "OriginStatus": 200,
  "Overhead": 71700,
  "RequestAddr": "hwilv3.rapyuta.io",
  "RequestContentSize": 0,
  "RequestCount": 177433,
  "RequestHost": "hwilv3.rapyuta.io",
  "RequestMethod": "GET",
  "RequestPath": "/device/",
  "RequestPort": "-",
  "RequestProtocol": "HTTP/1.1",
  "RequestScheme": "https",
  "RetryAttempts": 0,
  "RouterName": "websecure-hwil-hwilv2-hwilv3-rapyuta-io@kubernetes",
  "ServiceAddr": "10.224.2.57:8000",
  "ServiceName": "hwil-hwil-80@kubernetes",
  "ServiceURL": {
    "Scheme": "http",
    "Opaque": "",
    "User": null,
    "Host": "10.224.2.57:8000",
    "Path": "",
    "RawPath": "",
    "OmitHost": false,
    "ForceQuery": false,
    "RawQuery": "",
    "Fragment": "",
    "RawFragment": ""
  },
  "StartLocal": "2025-06-27T05:57:31.288452645Z",
  "StartUTC": "2025-06-27T05:57:31.288452645Z",
  "TLSCipher": "TLS_AES_128_GCM_SHA256",
  "TLSVersion": "1.3",
  "downstream_Allow": "GET, POST, HEAD, OPTIONS",
  "downstream_Content-Length": "23403",
  "downstream_Content-Type": "application/json",
  "downstream_Cross-Origin-Opener-Policy": "same-origin",
  "downstream_Date": "Fri, 27 Jun 2025 05:57:31 GMT",
  "downstream_Referrer-Policy": "same-origin",
  "downstream_Server": "gunicorn",
  "downstream_Vary": "Accept",
  "downstream_X-Content-Type-Options": "nosniff",
  "downstream_X-Frame-Options": "DENY",
  "entryPointName": "websecure",
  "level": "info",
  "msg": "",
  "origin_Allow": "GET, POST, HEAD, OPTIONS",
  "origin_Content-Length": "23403",
  "origin_Content-Type": "application/json",
  "origin_Cross-Origin-Opener-Policy": "same-origin",
  "origin_Date": "Fri, 27 Jun 2025 05:57:31 GMT",
  "origin_Referrer-Policy": "same-origin",
  "origin_Server": "gunicorn",
  "origin_Vary": "Accept",
  "origin_X-Content-Type-Options": "nosniff",
  "origin_X-Frame-Options": "DENY",
  "request_Accept": "*/*",
  "request_Accept-Encoding": "gzip, deflate",
  "request_Authorization": "Basic YW5zaWJsZTpyYXB5dXRhQGJscg==",
  "request_Connection": "keep-alive",
  "request_User-Agent": "rapyuta_io/1.17.1 CPython/3.10.14 python-requests/2.32.3",
  "request_X-Email-Id": "amit.singh@rapyuta-robotics.com",
  "request_X-Forwarded-Host": "hwilv3.rapyuta.io",
  "request_X-Forwarded-Port": "443",
  "request_X-Forwarded-Proto": "https",
  "request_X-Forwarded-Server": "traefik-655d848844-vf8hc",
  "request_X-Real-Ip": "103.163.65.90",
  "time": "2025-06-27T05:57:31Z"
}
```

```
"request_X-Email-Id": "amit.singh@rapyuta-robotics.com"
```