### PR TITLE
✨ feat: swap columns in the selection prompts

### DIFF
--- a/riocli/utils/__init__.py
+++ b/riocli/utils/__init__.py
@@ -139,12 +139,15 @@ def is_valid_uuid(uuid_to_test, version=4):
     return str(uuid_obj) == uuid_to_test
 
 
-def tabulate_data(data: typing.List[typing.List], headers: typing.List[str] = None):
+def tabulate_data(
+        data: typing.List[typing.List],
+        headers: typing.Union[typing.Iterable[str], str, None] = None,
+        table_format: str = "simple",
+):
     """
     Prints data in tabular format
     """
     # https://github.com/astanin/python-tabulate#table-format
-    table_format = "simple"
     header_foreground = "yellow"
 
     if headers:

--- a/riocli/utils/selector.py
+++ b/riocli/utils/selector.py
@@ -18,6 +18,7 @@ import click
 from click import types
 
 from riocli.constants import Colors
+from riocli.utils import tabulate_data
 
 
 def show_selection(
@@ -52,13 +53,17 @@ def _show_selection_list(
     highlight_item: Any = None,
 ) -> Any:
     click.secho(header, fg=Colors.YELLOW)
-
+    data = []
     for idx, opt in enumerate(ranger):
-        fmt = "{}) {}".format(idx + 1, opt)
+        idx_column = f"{idx+1})"
+        opt_column = opt
         if highlight_item is not None and opt == highlight_item:
-            fmt = click.style(fmt, bold=True, italic=True)
+            idx_column = click.style(idx_column, bold=True, italic=True)
+            opt_column = click.style(opt_column, bold=True, italic=True)
 
-        click.secho(fmt)
+        data.append([idx_column, opt_column])
+
+    tabulate_data(data, header=(), table_format="plain")
 
     prompt = click.style(prompt, fg=Colors.BLUE)
     choice = click.prompt(prompt, type=types.IntParamType())
@@ -74,17 +79,27 @@ def _show_selection_dict(
     highlight_item: Any = None,
 ) -> Any:
     click.secho(header, fg=Colors.YELLOW)
+    data = []
 
     for idx, key in enumerate(ranger):
-        if show_keys:
-            fmt = "{}) {} - {}".format(idx + 1, ranger[key], key)
-        else:
-            fmt = "{}) {}".format(idx + 1, ranger[key])
+        row = []
 
+        idx_column = f"{idx + 1})"
+        key_column = key
+        value_column = f"{ranger[key]}"
         if highlight_item is not None and key == highlight_item:
-            fmt = click.style(fmt, bold=True, italic=True)
+            idx_column = click.style(idx_column, bold=True, italic=True)
+            key_column = click.style(key_column, bold=True, italic=True)
+            value_column = click.style(value_column, bold=True, italic=True)
 
-        click.secho(fmt)
+        row.append(idx_column)
+        row.append(value_column)
+        if show_keys:
+            row.append(key_column)
+
+        data.append(row)
+
+    tabulate_data(data, headers=(), table_format="plain")
 
     prompt = click.style(prompt, fg=Colors.BLUE)
     choice = click.prompt(prompt, type=types.IntParamType())


### PR DESCRIPTION
This change swaps the Value and Key in the selection prompt for easier
readability. The values are not fixed-length like keys, so I've updated the
selector to use tabulate to properly align the columns.

```shellsession
~/.local/src/work/rapyuta-io-cli $ uv run rio package inspect sleep-cloud
Following packages were found with the same name
1)  sleep-cloud (v1.0.0)  pkg-d1r1unqqm37s73cuorn0
2)  sleep-cloud (v2.0.0)  pkg-d1t4edr1afqc738amaq0
Select the option:

~/.local/src/work/rapyuta-io-cli [1] $ DEBUG=true uv run rio auth login --email 'qa.rapyuta+e2e@gmail.com'
Password:
⚠️ Config already exists. Do you want to override the existing config? [y/N]: y
Select an organization:
1)  Rapyuta   org-wvnwcmvfkbajavjetttcutga
2)  Rapyuta2  org-xynwcmvfkbajavjetttcuorg
Select the option: Aborted!
```

Resolves rapyuta-robotics/rapyuta_io#889