### PR TITLE
ci: migrate GitHub Actions to self-hosted ARC runners

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   verify:
     name: Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
     - uses: actions/checkout@v4
       name: Checkout code

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   code-quality-checks:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
           args: "format --check"
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     environment: release
     permissions:
       id-token: write

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -3,7 +3,7 @@ on: [ push ]
 
 jobs:
   linux-python-compatibility:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     strategy:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/upload-appimage.yml
+++ b/.github/workflows/upload-appimage.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   upload-appimage:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Migrates all GitHub Actions workflows from GitHub-hosted runners (`ubuntu-latest` / `ubuntu-22.04`) to our self-hosted ARC runners (`aks-spot-4cpu`).

This uses the runner scale sets defined in `rr_ci_apps/gha-arc` which run on our AKS cluster with spot instances for cost optimization.