### PR TITLE
fix: constrain AppImage wheels to manylinux_2_28 for Ubuntu 20.04

### DIFF
--- a/scripts/build-rio-appimage.sh
+++ b/scripts/build-rio-appimage.sh
@@ -30,6 +30,27 @@ cd scripts
 ./squashfs-root/AppRun -m pip install --upgrade pip
 ./squashfs-root/AppRun -m pip install rapyuta_io_cli-*.whl
 
+# Force-reinstall cryptography with a manylinux_2_28 wheel so the
+# AppImage works on systems with GLIBC >= 2.28 (Ubuntu 20.04+).
+# Without this, CI hosts with newer GLIBC pull manylinux_2_34 wheels
+# whose _rust.abi3.so requires GLIBC_2.33 symbols unavailable on
+# older distros.
+WHEEL_DIR=/tmp/rio-wheels
+rm -rf "$WHEEL_DIR" && mkdir -p "$WHEEL_DIR"
+./squashfs-root/AppRun -m pip download \
+    --only-binary=:all: \
+    --platform manylinux_2_28_x86_64 \
+    --python-version 3.13 \
+    --implementation cp \
+    --abi cp313 --abi abi3 --abi none \
+    --no-deps \
+    --dest "$WHEEL_DIR" \
+    cryptography
+./squashfs-root/AppRun -m pip install \
+    --force-reinstall --no-deps \
+    --no-index --find-links "$WHEEL_DIR" \
+    cryptography
+
 # Replacing AppRun with a custom script that uses Python's -I (isolated
 # mode) to completely prevent host Python environment leakage.
 cp AppRun squashfs-root/AppRun


### PR DESCRIPTION
Problem
The rio AppImage crashes on Ubuntu 20.04 (GLIBC 2.31) with:


```ImportError: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.33' not found  (required by .../cryptography/hazmat/bindings/_rust.abi3.so)```

This breaks rio cli.

Root Cause
The AppImage bundles python3.13.7-cp313-cp313-manylinux_2_28_x86_64 (targeting GLIBC 2.28+), but pip install runs on CI (Ubuntu 22.04+, GLIBC ≥ 2.35) which selects the manylinux_2_34 wheel for cryptography>=44. That wheel's _rust.abi3.so requires GLIBC 2.33 symbols unavailable on Ubuntu 20.04.

Fix
Constrain the AppImage build to only download wheels compatible with manylinux_2_28 using a two-step pip download + pip install --no-index approach. This ensures all native extensions (cryptography, etc.) are built against GLIBC ≤ 2.28, matching the bundled Python.