### PR TITLE
fix(configtree): handle invalid YAML values in export (e.g. log format strings with '%')

### DIFF
--- a/riocli/configtree/util.py
+++ b/riocli/configtree/util.py
@@ -288,8 +288,12 @@ def combine_metadata(keys: dict) -> dict:
             data = b64decode(data).decode("utf-8")
             # The data received from the API is always in string format. To use
             # appropriate data-type in Python (as well in exports), we are
-            # passing it through YAML parser.
-            data = yaml.safe_load(data)
+            # passing it through YAML parser. Fall back to the raw string if
+            # the value is not valid YAML (e.g. log format strings with '%').
+            try:
+                data = yaml.safe_load(data)
+            except yaml.YAMLError:
+                pass
         metadata = val.get("metadata", None)
 
         if metadata:

--- a/riocli/configtree/util.py
+++ b/riocli/configtree/util.py
@@ -285,15 +285,15 @@ def combine_metadata(keys: dict) -> dict:
     for key, val in keys.items():
         data = val.get("data", None)
         if data is not None:
-            data = b64decode(data).decode("utf-8")
+            raw = b64decode(data).decode("utf-8")
             # The data received from the API is always in string format. To use
             # appropriate data-type in Python (as well in exports), we are
             # passing it through YAML parser. Fall back to the raw string if
             # the value is not valid YAML (e.g. log format strings with '%').
             try:
-                data = yaml.safe_load(data)
+                data = yaml.safe_load(raw)
             except yaml.YAMLError:
-                pass
+                data = raw
         metadata = val.get("metadata", None)
 
         if metadata:


### PR DESCRIPTION
## Summary

- `rio configtree export default` crashed with a YAML parse error when any key value contained `%` characters (e.g. log format strings like `[%(levelname)s] [%(asctime)s]`)
- Root cause: `combine_metadata` in `util.py` unconditionally calls `yaml.safe_load()` on every value — `[%(...)s]` is a valid string but invalid YAML flow sequence token
- Fix: wrap `yaml.safe_load()` in a `try/except yaml.YAMLError` and fall back to the raw string; all valid YAML types (int, bool, float, dict, list) continue to be parsed correctly

## Test plan

- [x] Manual test: `combine_metadata` correctly returns log format string as raw `str` while still parsing `8080` → `int`, `true` → `bool`
- [ ] Run `rio configtree export default` against a tree that has a key with a `%`-containing value and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)