### PR TITLE
fix(configtree): keep non-YAML values as raw strings during export

### DIFF
--- a/riocli/configtree/util.py
+++ b/riocli/configtree/util.py
@@ -289,7 +289,13 @@ def combine_metadata(keys: dict) -> dict:
             # The data received from the API is always in string format. To use
             # appropriate data-type in Python (as well in exports), we are
             # passing it through YAML parser.
-            data = yaml.safe_load(data)
+            try:
+                data = yaml.safe_load(data)
+            except yaml.YAMLError:
+                # Values are not guaranteed to be valid YAML, e.g. logging
+                # format strings like "[%(levelname)s] ...". Keep the raw
+                # string as-is when parsing fails.
+                pass
         metadata = val.get("metadata", None)
 
         if metadata:

--- a/tests/unit/configtree/test_util.py
+++ b/tests/unit/configtree/test_util.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for configtree utility functions."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+
+from riocli.configtree.util import combine_metadata
+
+
+def _encode(value: str) -> str:
+    return b64encode(value.encode("utf-8")).decode("utf-8")
+
+
+class TestCombineMetadata:
+    """Tests for combine_metadata()."""
+
+    def test_yaml_scalars_are_typed(self):
+        keys = {
+            "a/int": {"data": _encode("42")},
+            "a/bool": {"data": _encode("true")},
+            "a/str": {"data": _encode("hello")},
+        }
+
+        result = combine_metadata(keys)
+
+        assert result["a/int"] == 42
+        assert result["a/bool"] is True
+        assert result["a/str"] == "hello"
+
+    def test_non_yaml_value_is_kept_as_raw_string(self):
+        # Logging format strings are not valid YAML: the leading '[' starts a
+        # flow sequence and '%' cannot start a token. They must survive as-is
+        # instead of crashing the export.
+        fmt = "[%(levelname)s] [%(asctime)s] [%(name)s] <%(process)d>: %(message)s"
+        keys = {"wms/logging/format": {"data": _encode(fmt)}}
+
+        result = combine_metadata(keys)
+
+        assert result["wms/logging/format"] == fmt
+
+    def test_metadata_is_combined_with_value(self):
+        keys = {
+            "a/key": {
+                "data": _encode("value"),
+                "metadata": {"contentType": "kv"},
+            }
+        }
+
+        result = combine_metadata(keys)
+
+        assert result["a/key"] == {
+            "value": "value",
+            "metadata": {"contentType": "kv"},
+        }
+
+    def test_key_without_data(self):
+        keys = {"a/key": {}}
+
+        result = combine_metadata(keys)
+
+        assert result["a/key"] is None


### PR DESCRIPTION
## Problem

`rio configtree export <tree>` crashes when any key holds a value that is not valid YAML:

```
❌ Failed to export keys: while scanning for the next token
found character '%' that cannot start any token
  in "<unicode string>", line 1, column 2:
    [%(levelname)s] [%(asctime)s] [%( ...
```

`combine_metadata()` in `riocli/configtree/util.py` passes every decoded key value through `yaml.safe_load()` to infer its data type. A Python logging format string such as `[%(levelname)s] [%(asctime)s] ...` starts a YAML flow sequence (`[`) and then hits `%`, which cannot start a token — the resulting `ScannerError` aborts the entire export. Any command going through `combine_metadata()` (`export`, `diff`, `merge`) is affected.

Hit in production on the `nx-daiba-001` project tree, which carries a logging format string under `wms/`.

## Fix

Fall back to the raw string when `yaml.safe_load()` raises a `YAMLError`. Valid YAML scalars (ints, bools, etc.) keep their inferred types as before.

## Testing

- Added unit tests for `combine_metadata()` under `tests/unit/configtree/` covering type inference, the non-YAML fallback, metadata combination, and data-less keys — `uv run pytest tests/unit/configtree/ -v` → 4 passed.
- Verified end-to-end against the affected production tree: `rio configtree export default` now exports all 6 files as valid JSON with the format string intact.
- `ruff check` and `ruff format --check` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)