### PR TITLE
fix: de-deduplicate mount volumes in init-perm sidecar container

### DIFF
--- a/riocli/compose/populate.py
+++ b/riocli/compose/populate.py
@@ -144,7 +144,7 @@ def _build_fixup_cmd(entry: dict) -> str:
 
 
 def get_volumes_requiring_fixup(deployments: dict[str, dict]) -> list[dict]:
-    fixup = []
+    volumes_by_path: dict[tuple, dict] = {}
     for dep in deployments.values():
         for volume in dep.spec.get("volumes", []):
             uid, gid, perm = volume.get("uid"), volume.get("gid"), volume.get("perm")
@@ -177,16 +177,16 @@ def get_volumes_requiring_fixup(deployments: dict[str, dict]) -> list[dict]:
                         f"perm must be a valid octal permission value (0–7777), got: {perm}"
                     )
 
-            fixup.append(
-                {
+            key = (host, container)
+            if key not in volumes_by_path:
+                volumes_by_path[key] = {
                     "host": host,
                     "container": container,
                     "uid": uid,
                     "gid": gid,
                     "perm": perm,
                 }
-            )
-    return fixup
+    return list(volumes_by_path.values())
 
 
 def _is_ros_enabled(deployment: Munch, package: Munch) -> bool:

--- a/tests/unit/compose/test_populate.py
+++ b/tests/unit/compose/test_populate.py
@@ -4,7 +4,106 @@ import os
 import stat
 import subprocess
 
-from riocli.compose.populate import _build_fixup_cmd
+from munch import munchify
+
+from riocli.compose.populate import _build_fixup_cmd, get_volumes_requiring_fixup
+
+
+def _make_deployment(volumes: list[dict]) -> object:
+    return munchify({"spec": {"volumes": volumes}})
+
+
+class TestGetVolumesRequiringFixup:
+    def test_deduplicates_same_host_and_container(self):
+        dep = _make_deployment(
+            [
+                {
+                    "subPath": "/host/path",
+                    "mountPath": "/container/path",
+                    "uid": 1000,
+                    "gid": 1000,
+                    "perm": 755,
+                },
+                {
+                    "subPath": "/host/path",
+                    "mountPath": "/container/path",
+                    "uid": 1000,
+                    "gid": 1000,
+                    "perm": 755,
+                },
+            ]
+        )
+        result = get_volumes_requiring_fixup({"dep": dep})
+        assert len(result) == 1
+        assert result[0]["host"] == "/host/path"
+        assert result[0]["container"] == "/container/path"
+
+    def test_deduplicates_across_deployments(self):
+        vol = {
+            "subPath": "/host/path",
+            "mountPath": "/container/path",
+            "uid": 1000,
+            "gid": 1000,
+            "perm": 755,
+        }
+        dep1 = _make_deployment([vol])
+        dep2 = _make_deployment([vol])
+        result = get_volumes_requiring_fixup({"dep1": dep1, "dep2": dep2})
+        assert len(result) == 1
+
+    def test_distinct_mounts_are_all_returned(self):
+        dep = _make_deployment(
+            [
+                {
+                    "subPath": "/host/a",
+                    "mountPath": "/container/a",
+                    "uid": 1000,
+                    "gid": 1000,
+                    "perm": 755,
+                },
+                {
+                    "subPath": "/host/b",
+                    "mountPath": "/container/b",
+                    "uid": 1000,
+                    "gid": 1000,
+                    "perm": 755,
+                },
+            ]
+        )
+        result = get_volumes_requiring_fixup({"dep": dep})
+        assert len(result) == 2
+
+    def test_skips_volumes_without_uid_gid_perm(self):
+
+        dep = _make_deployment(
+            [
+                {"subPath": "/host/path", "mountPath": "/container/path"},
+            ]
+        )
+        result = get_volumes_requiring_fixup({"dep": dep})
+        assert result == []
+
+    def test_same_host_different_container_both_kept(self):
+        dep = _make_deployment(
+            [
+                {
+                    "subPath": "/host/path",
+                    "mountPath": "/container/a",
+                    "uid": 1000,
+                    "gid": 1000,
+                    "perm": 755,
+                },
+                {
+                    "subPath": "/host/path",
+                    "mountPath": "/container/b",
+                    "uid": 1000,
+                    "gid": 1000,
+                    "perm": 755,
+                },
+            ]
+        )
+        result = get_volumes_requiring_fixup({"dep": dep})
+        assert len(result) == 2
 
 
 class TestBuildFixupCmdStructure:

--- a/tests/unit/compose/test_populate.py
+++ b/tests/unit/compose/test_populate.py
@@ -4,12 +4,12 @@ import os
 import stat
 import subprocess
 
-from munch import munchify
+from munch import Munch, munchify
 
 from riocli.compose.populate import _build_fixup_cmd, get_volumes_requiring_fixup
 
 
-def _make_deployment(volumes: list[dict]) -> object:
+def _make_deployment(volumes: list[dict]) -> Munch:
     return munchify({"spec": {"volumes": volumes}})
 
 
@@ -74,7 +74,6 @@ class TestGetVolumesRequiringFixup:
         assert len(result) == 2
 
     def test_skips_volumes_without_uid_gid_perm(self):
-
         dep = _make_deployment(
             [
                 {"subPath": "/host/path", "mountPath": "/container/path"},


### PR DESCRIPTION
Mounting volumes from various template file may have same path - which can cause failure in docker compose up operation as <=2.24 version doesn't handle it - explicitly need to remove the duplication.