### PR TITLE
feat(update): host AppImages on Azure Blob to fix GitHub rate-limit on rio update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,6 @@ jobs:
           MINIO_URL: ${{ secrets.MINIO_URL }}
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET: ${{ secrets.MINIO_SECRET }}
+          CHANNEL: release
+          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          AZURE_SAS_TOKEN: ${{ secrets.AZURE_SAS_TOKEN }}

--- a/.github/workflows/upload-appimage.yml
+++ b/.github/workflows/upload-appimage.yml
@@ -26,14 +26,6 @@ jobs:
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
           AZURE_SAS_TOKEN: ${{ secrets.AZURE_SAS_TOKEN }}
 
-      - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: appimages
-          path: ${{ github.workspace }}/scripts/rio*.AppImage
-          if-no-files-found: error
-          retention-days: 15
-
       - name: Install GitHub CLI
         run: |
           sudo apt-get update
@@ -42,8 +34,12 @@ jobs:
       - name: Comment blob link on PR
         if: github.event_name == 'pull_request'
         run: |
-          BRANCH="${{ github.head_ref }}"
           ACCOUNT="${{ secrets.AZURE_STORAGE_ACCOUNT }}"
+          if [ -z "$ACCOUNT" ]; then
+            echo "No Azure account secret (fork PR?) — skipping blob comment"
+            exit 0
+          fi
+          BRANCH="${{ github.head_ref }}"
           FILE=$(ls scripts/rio*.AppImage | xargs -n1 basename | head -n1)
           URL="https://${ACCOUNT}.blob.core.windows.net/dev/${BRANCH}/${FILE}"
           gh pr comment "$PR_NUMBER" --edit-last -b "**🤖 PR AppImage:** [$FILE]($URL)" \

--- a/.github/workflows/upload-appimage.yml
+++ b/.github/workflows/upload-appimage.yml
@@ -2,7 +2,6 @@ name: ⬆️ Upload AppImage
 on:
   push:
     branches:
-    - main
     - devel
   pull_request:
 
@@ -20,9 +19,12 @@ jobs:
         run: ./scripts/build-rio-appimage.sh
         shell: bash
         env:
+          CHANNEL: ${{ github.event_name == 'pull_request' && 'dev' || 'devel' }}
           MINIO_URL: ${{ secrets.MINIO_URL }}
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET: ${{ secrets.MINIO_SECRET }}
+          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          AZURE_SAS_TOKEN: ${{ secrets.AZURE_SAS_TOKEN }}
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
@@ -37,42 +39,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install gh
 
-      - name: Edit the last bot comment
-        id: edit-comment
+      - name: Comment blob link on PR
         if: github.event_name == 'pull_request'
         run: |
-          set -e
-          gh pr comment $PR_NUMBER --edit-last -b "
-          **🤖 Pull Request [Artifacts](https://github.com/rapyuta-robotics/rapyuta-io-cli/actions/runs/"$RUN_ID") (#"$RUN_ID") 🎉**
-          "
+          BRANCH="${{ github.head_ref }}"
+          ACCOUNT="${{ secrets.AZURE_STORAGE_ACCOUNT }}"
+          FILE=$(ls scripts/rio*.AppImage | xargs -n1 basename | head -n1)
+          URL="https://${ACCOUNT}.blob.core.windows.net/dev/${BRANCH}/${FILE}"
+          gh pr comment "$PR_NUMBER" --edit-last -b "**🤖 PR AppImage:** [$FILE]($URL)" \
+            || gh pr comment "$PR_NUMBER" -b "**🤖 PR AppImage:** [$FILE]($URL)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
-          PR_NUMBER: ${{ github.event.number }}
-        continue-on-error: true
-
-      - name: Delete existing bot comments
-        if: steps.edit-comment.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          # Get all comments on the PR where the author is the bot
-          COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments --jq '.[] | select(.user.login == "github-actions[bot]") | .id')
-      
-          # Loop through each bot comment and delete it
-          for COMMENT_ID in $COMMENTS; do
-            gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X DELETE
-          done
-
-      - name: Artifact Comment on PR
-        # if: github.event_name == 'pull_request'
-        if: steps.edit-comment.outcome == 'failure'
-        run: |
-          gh pr comment $PR_NUMBER -b  "
-          **🤖 Pull Request [Artifacts](https://github.com/rapyuta-robotics/rapyuta-io-cli/actions/runs/"$RUN_ID") (#"$RUN_ID") 🎉**
-          "
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/upload-appimage.yml
+++ b/.github/workflows/upload-appimage.yml
@@ -39,7 +39,9 @@ jobs:
             echo "No Azure account secret (fork PR?) — skipping blob comment"
             exit 0
           fi
-          BRANCH="${{ github.head_ref }}"
+          # Same sanitization as build-rio-appimage.sh so the link matches the
+          # actual dev/<safe-branch>/ upload path.
+          BRANCH=$(echo "${{ github.head_ref }}" | tr -c '0-9A-Za-z' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
           FILE=$(ls scripts/rio*.AppImage | xargs -n1 basename | head -n1)
           URL="https://${ACCOUNT}.blob.core.windows.net/dev/${BRANCH}/${FILE}"
           gh pr comment "$PR_NUMBER" --edit-last -b "**🤖 PR AppImage:** [$FILE]($URL)" \

--- a/docs/superpowers/plans/2026-06-14-rio-appimage-azure-blob.md
+++ b/docs/superpowers/plans/2026-06-14-rio-appimage-azure-blob.md
@@ -1,0 +1,812 @@
+# rio AppImage on Azure Blob — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make AppImage `rio update` download from public-read Azure Blob containers (channel-keyed) instead of the rate-limited `api.github.com` path; leave the pip/PyPI path untouched.
+
+**Architecture:** A new focused module `riocli/utils/appimage.py` holds pure, unit-testable helpers (channel-from-version, URL builders, update-available check) plus the network fetch/replace. `bootstrap.py`'s `update` command branches: pip → existing PyPI flow; AppImage → new module. CI (`build-rio-appimage.sh`, `upload-appimage.yml`, `release.yml`) stamps a channel suffix into `__version__` for non-release builds and uploads the AppImage + a `latest.json` manifest to the matching container via azcopy.
+
+**Tech Stack:** Python 3.13, Click, `requests`, `semver`, pytest (unit, no network). Bash + GitHub Actions + azcopy for CI. Azure Blob Storage (public-read containers).
+
+**Spec:** `docs/superpowers/specs/2026-06-14-rio-appimage-azure-blob-design.md`
+
+---
+
+## File Structure
+
+**New:**
+- `riocli/utils/appimage.py` — channel detection, manifest/URL builders, update-available check, manifest fetch, download + executable swap. One responsibility: AppImage self-update against Azure Blob.
+- `tests/unit/utils/test_appimage.py` — unit tests (pure functions + mocked network).
+
+**Modified:**
+- `riocli/utils/__init__.py` — remove the old GitHub-based `update_appimage` (lines 213-261). Keep `check_for_updates`, `is_pip_installation`, `pip_install_cli`.
+- `riocli/bootstrap.py` — swap the `update_appimage` import for the new module; rewrite the `update` command's AppImage branch (lines 130-149, 52-58).
+- `scripts/build-rio-appimage.sh` — stamp channel suffix for non-release builds; after build, compute sha256, write `latest.json`, azcopy-upload to the channel container.
+- `.github/workflows/upload-appimage.yml` — PR → `dev/<branch>/`; push `devel` → `devel`; drop `main` trigger; pass `CHANNEL` + Azure secrets; PR comment links to blob URL.
+- `.github/workflows/release.yml` — pass `CHANNEL=release` + Azure secrets to semantic-release env.
+
+**Reference (do not change):** `riocli/chart/util.py` (Azure access pattern), `scripts/bump-version.sh` (sed stamping pattern), `tests/unit/test_chart_branch_util.py` (URL test pattern).
+
+---
+
+## Task 1: Channel detection + URL builders (pure functions)
+
+**Files:**
+- Create: `riocli/utils/appimage.py`
+- Test: `tests/unit/utils/test_appimage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/utils/test_appimage.py
+# Copyright 2026 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from riocli.utils import appimage
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("10.6.0", appimage.CHANNEL_RELEASE),
+        ("10.6.0-devel+abc1234", appimage.CHANNEL_DEVEL),
+        ("10.6.0-devel.3+abc1234", appimage.CHANNEL_DEVEL),
+        ("10.6.0-dev.feature-x+abc1234", None),
+        ("10.6.0-rc.1+abc1234", None),
+    ],
+)
+def test_channel_for_version(version, expected):
+    assert appimage.channel_for_version(version) == expected
+
+
+def test_manifest_url_default_account():
+    assert appimage.manifest_url("devel") == (
+        f"{appimage.DEFAULT_ACCOUNT_URL}/devel/latest.json"
+    )
+
+
+def test_appimage_url_default_account():
+    assert appimage.appimage_url("release", "rio-10.6.0-x86_64.AppImage") == (
+        f"{appimage.DEFAULT_ACCOUNT_URL}/release/rio-10.6.0-x86_64.AppImage"
+    )
+
+
+def test_base_url_env_override(monkeypatch):
+    monkeypatch.setenv("RIO_APPIMAGE_BASE_URL", "https://staging.example.com")
+    assert appimage.manifest_url("devel") == (
+        "https://staging.example.com/devel/latest.json"
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/utils/test_appimage.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'riocli.utils.appimage'`
+
+- [ ] **Step 3: Write the module**
+
+```python
+# riocli/utils/appimage.py
+# Copyright 2026 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+from hashlib import sha256
+from pathlib import Path
+from shutil import move
+from tempfile import TemporaryDirectory
+
+import click
+import requests
+import semver
+
+from riocli.constants import Colors, Symbols
+
+CHANNEL_RELEASE = "release"
+CHANNEL_DEVEL = "devel"
+
+# Public-read Azure Blob account that hosts the rio AppImages.
+# NOTE: confirm the final account name with infra before the first
+# blob-aware release (spec open question #1). Overridable via env for
+# staging/testing.
+DEFAULT_ACCOUNT_URL = "https://riocliartifacts.blob.core.windows.net"
+
+
+def base_url() -> str:
+    """Base URL of the AppImage blob account (env-overridable)."""
+    return os.environ.get("RIO_APPIMAGE_BASE_URL", DEFAULT_ACCOUNT_URL)
+
+
+def channel_for_version(version: str) -> str | None:
+    """Map a CLI version to its update channel.
+
+    Plain semver -> release. A ``devel``/``devel.N`` prerelease -> devel.
+    Anything else (``dev.<branch>``, ``rc.N``, etc.) is not an
+    auto-updatable channel and returns None.
+    """
+    pre = semver.Version.parse(version).prerelease
+    if pre is None:
+        return CHANNEL_RELEASE
+    if pre == CHANNEL_DEVEL or pre.startswith(f"{CHANNEL_DEVEL}."):
+        return CHANNEL_DEVEL
+    return None
+
+
+def manifest_url(channel: str) -> str:
+    return f"{base_url()}/{channel}/latest.json"
+
+
+def appimage_url(channel: str, filename: str) -> str:
+    return f"{base_url()}/{channel}/{filename}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/utils/test_appimage.py -v`
+Expected: PASS (all parametrized cases + URL tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riocli/utils/appimage.py tests/unit/utils/test_appimage.py
+git commit -m "feat(update): add AppImage channel detection and blob URL builders"
+```
+
+---
+
+## Task 2: Update-available check
+
+**Files:**
+- Modify: `riocli/utils/appimage.py`
+- Test: `tests/unit/utils/test_appimage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/utils/test_appimage.py
+
+def test_update_available_release_newer():
+    assert appimage.update_available("release", "10.7.0", "10.6.0") is True
+
+
+def test_update_available_release_same():
+    assert appimage.update_available("release", "10.6.0", "10.6.0") is False
+
+
+def test_update_available_release_older_is_false():
+    # never offer a downgrade on the release channel
+    assert appimage.update_available("release", "10.5.0", "10.6.0") is False
+
+
+def test_update_available_devel_differs():
+    # devel builds differ only by +build metadata, which semver ignores;
+    # any difference in the full version string means a newer commit.
+    assert appimage.update_available(
+        "devel", "10.6.0-devel+bbb2222", "10.6.0-devel+aaa1111"
+    ) is True
+
+
+def test_update_available_devel_same():
+    assert appimage.update_available(
+        "devel", "10.6.0-devel+aaa1111", "10.6.0-devel+aaa1111"
+    ) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/utils/test_appimage.py -k update_available -v`
+Expected: FAIL — `AttributeError: module 'riocli.utils.appimage' has no attribute 'update_available'`
+
+- [ ] **Step 3: Implement**
+
+```python
+# append to riocli/utils/appimage.py
+
+def update_available(channel: str, remote_version: str, current_version: str) -> bool:
+    """Whether ``remote_version`` should replace ``current_version``.
+
+    Release channel uses semver precedence (no downgrades). Devel builds
+    share a base version and differ only by ignored +build metadata, so
+    compare the full string for any change.
+    """
+    if channel == CHANNEL_DEVEL:
+        return remote_version != current_version
+    return semver.Version.parse(remote_version).compare(current_version) > 0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/utils/test_appimage.py -k update_available -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riocli/utils/appimage.py tests/unit/utils/test_appimage.py
+git commit -m "feat(update): add channel-aware update-available check"
+```
+
+---
+
+## Task 3: Manifest fetch + download/replace with checksum
+
+**Files:**
+- Modify: `riocli/utils/appimage.py`
+- Test: `tests/unit/utils/test_appimage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/utils/test_appimage.py
+from hashlib import sha256
+from unittest.mock import MagicMock
+
+
+def _fake_response(content=b"", json_data=None):
+    resp = MagicMock()
+    resp.content = content
+    resp.raise_for_status = MagicMock()
+    if json_data is not None:
+        resp.json = MagicMock(return_value=json_data)
+    return resp
+
+
+def test_fetch_manifest(monkeypatch):
+    manifest = {"version": "10.6.0-devel+abc", "file": "rio.AppImage", "sha256": "x"}
+    monkeypatch.setattr(
+        appimage.requests, "get", lambda url, **kw: _fake_response(json_data=manifest)
+    )
+    assert appimage.fetch_manifest("devel") == manifest
+
+
+def test_download_and_replace_writes_target(monkeypatch, tmp_path):
+    payload = b"APPIMAGE-BYTES"
+    digest = sha256(payload).hexdigest()
+    manifest = {"version": "10.6.0", "file": "rio.AppImage", "sha256": digest}
+    monkeypatch.setattr(
+        appimage.requests, "get", lambda url, **kw: _fake_response(content=payload)
+    )
+    target = tmp_path / "rio"
+    target.write_bytes(b"OLD")
+    appimage.download_and_replace("release", manifest, target=str(target))
+    assert target.read_bytes() == payload
+
+
+def test_download_and_replace_checksum_mismatch(monkeypatch, tmp_path):
+    manifest = {"version": "10.6.0", "file": "rio.AppImage", "sha256": "deadbeef"}
+    monkeypatch.setattr(
+        appimage.requests, "get", lambda url, **kw: _fake_response(content=b"bytes")
+    )
+    target = tmp_path / "rio"
+    target.write_bytes(b"OLD")
+    with pytest.raises(Exception, match="[Cc]hecksum"):
+        appimage.download_and_replace("release", manifest, target=str(target))
+    # original must be untouched on mismatch
+    assert target.read_bytes() == b"OLD"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/utils/test_appimage.py -k "fetch_manifest or download_and_replace" -v`
+Expected: FAIL — attributes `fetch_manifest` / `download_and_replace` do not exist
+
+- [ ] **Step 3: Implement**
+
+```python
+# append to riocli/utils/appimage.py
+
+def fetch_manifest(channel: str) -> dict:
+    """Fetch and parse the channel's latest.json (anonymous GET)."""
+    resp = requests.get(manifest_url(channel))
+    resp.raise_for_status()
+    return resp.json()
+
+
+def download_and_replace(channel: str, manifest: dict, target: str | None = None) -> None:
+    """Download the AppImage named in the manifest, verify its sha256,
+    then atomically replace ``target`` (defaults to the running executable).
+    """
+    if target is None:
+        target = sys.executable
+
+    resp = requests.get(appimage_url(channel, manifest["file"]))
+    resp.raise_for_status()
+    content = resp.content
+
+    expected = manifest.get("sha256")
+    if expected and sha256(content).hexdigest() != expected:
+        raise Exception("Checksum mismatch for the downloaded AppImage")
+
+    with TemporaryDirectory() as tmp:
+        save_to = Path(tmp) / "rio"
+        save_to.write_bytes(content)
+        os.chmod(save_to, 0o755)
+        try:
+            os.remove(target)
+            move(save_to, target)
+        except OSError as e:
+            click.secho(
+                f"{Symbols.WARNING} Please consider running as a root user.",
+                fg=Colors.YELLOW,
+            )
+            raise e
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/utils/test_appimage.py -v`
+Expected: PASS (whole file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riocli/utils/appimage.py tests/unit/utils/test_appimage.py
+git commit -m "feat(update): fetch manifest and replace AppImage with checksum verify"
+```
+
+---
+
+## Task 4: Wire the new module into the `update` command
+
+**Files:**
+- Modify: `riocli/bootstrap.py` (imports lines 52-58; `update` command lines 130-149)
+- Modify: `riocli/utils/__init__.py` (remove old `update_appimage`, lines 213-261)
+- Test: `tests/unit/test_update_command.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_update_command.py
+# Copyright 2026 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from riocli.bootstrap import cli
+
+
+def test_update_devel_appimage_uses_blob():
+    """A devel AppImage runs the blob path, not the GitHub path."""
+    manifest = {
+        "version": "10.9.9-devel+newsha",
+        "file": "rio-10.9.9-devel+newsha-x86_64.AppImage",
+        "sha256": "x",
+    }
+    with (
+        patch("riocli.bootstrap.__version__", "10.6.0-devel+oldsha"),
+        patch("riocli.bootstrap.is_pip_installation", return_value=False),
+        patch("riocli.bootstrap.appimage.fetch_manifest", return_value=manifest) as fm,
+        patch("riocli.bootstrap.appimage.download_and_replace") as dr,
+    ):
+        result = CliRunner().invoke(cli, ["update", "--silent"])
+    assert result.exit_code == 0
+    fm.assert_called_once_with("devel")
+    dr.assert_called_once_with("devel", manifest)
+
+
+def test_update_dev_build_is_not_updatable():
+    """A feature-branch (dev.*) build refuses to auto-update."""
+    with (
+        patch("riocli.bootstrap.__version__", "10.6.0-dev.feature-x+sha"),
+        patch("riocli.bootstrap.is_pip_installation", return_value=False),
+        patch("riocli.bootstrap.appimage.fetch_manifest") as fm,
+    ):
+        result = CliRunner().invoke(cli, ["update", "--silent"])
+    assert result.exit_code == 0
+    assert "development build" in result.output.lower()
+    fm.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_update_command.py -v`
+Expected: FAIL — `riocli.bootstrap` has no attribute `appimage` (import not yet added)
+
+- [ ] **Step 3: Edit `riocli/bootstrap.py` imports**
+
+Replace the util import block (lines 52-58) — drop `update_appimage`, add the module import:
+
+```python
+from riocli.utils import (
+    AliasedGroup,
+    check_for_updates,
+    is_pip_installation,
+    pip_install_cli,
+)
+from riocli.utils import appimage
+```
+
+- [ ] **Step 4: Rewrite the `update` command body**
+
+Replace lines 130-149 (from `available, latest = check_for_updates(...)` through the `try/except`) with:
+
+```python
+    if is_pip_installation():
+        available, latest = check_for_updates(__version__)
+        if not available:
+            click.secho("🎉 You are using the latest version", fg=Colors.GREEN)
+            return
+        click.secho(f"🎉 A newer version ({latest}) is available.", fg=Colors.GREEN)
+        if not silent:
+            _ = click.confirm("Do you want to update?", abort=True, default=False)
+        try:
+            _ = pip_install_cli(version=latest)
+        except Exception as e:
+            click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
+            raise SystemExit(1) from e
+        click.secho(f"{Symbols.SUCCESS} Update successful!", fg=Colors.GREEN)
+        return
+
+    # AppImage installation: update from our Azure Blob channel.
+    channel = appimage.channel_for_version(__version__)
+    if channel is None:
+        click.secho(
+            f"{Symbols.WARNING} This is a development build; auto-update is "
+            "disabled. Rebuild from your branch or install a release.",
+            fg=Colors.YELLOW,
+        )
+        return
+
+    try:
+        manifest = appimage.fetch_manifest(channel)
+    except Exception as e:
+        click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
+        raise SystemExit(1) from e
+
+    if not appimage.update_available(channel, manifest["version"], __version__):
+        click.secho("🎉 You are using the latest version", fg=Colors.GREEN)
+        return
+
+    click.secho(
+        f"🎉 A newer version ({manifest['version']}) is available.", fg=Colors.GREEN
+    )
+    if not silent:
+        _ = click.confirm("Do you want to update?", abort=True, default=False)
+
+    try:
+        appimage.download_and_replace(channel, manifest)
+    except Exception as e:
+        click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
+        raise SystemExit(1) from e
+
+    click.secho(f"{Symbols.SUCCESS} Update successful!", fg=Colors.GREEN)
+```
+
+- [ ] **Step 5: Remove the old `update_appimage` from `riocli/utils/__init__.py`**
+
+Delete the entire `def update_appimage(version: str):` function (lines 213-261). Leave `check_for_updates`, `pip_install_cli`, `is_pip_installation` intact.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_update_command.py tests/unit/utils/test_appimage.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Lint + verify nothing else imports the removed symbol**
+
+Run: `grep -rn "update_appimage" riocli/ tests/`
+Expected: no matches (the import in bootstrap was removed)
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: clean (run `uv run ruff format .` if format check fails)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add riocli/bootstrap.py riocli/utils/__init__.py tests/unit/test_update_command.py
+git commit -m "feat(update): route AppImage updates through Azure Blob channels"
+```
+
+---
+
+## Task 5: Stamp channel suffix into `__version__` for non-release builds
+
+**Files:**
+- Modify: `scripts/build-rio-appimage.sh`
+
+Context: For `release`, `bump-version.sh` already set a plain semver `__version__` before this script runs, so `channel_for_version` returns `release` — no stamping needed. For `devel`/`dev`, the binary must report a channel-tagged version so the installed AppImage is self-describing.
+
+- [ ] **Step 1: Add a stamping block near the top of the build (before `uv build`)**
+
+Insert after the `mc` download lines (after line 14, before `# Creating rio-cli wheel`):
+
+```bash
+# Stamp a channel suffix into __version__ for non-release builds so the
+# installed AppImage knows which Azure Blob container to update from.
+# CHANNEL is set by the calling workflow (release|devel|dev). Release
+# builds are versioned upstream by bump-version.sh and are left as-is.
+CHANNEL="${CHANNEL:-dev}"
+if [[ "$CHANNEL" != "release" ]]; then
+  BASE_VERSION=$(grep -m1 '^__version__' riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
+  SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
+  if [[ "$CHANNEL" == "devel" ]]; then
+    STAMP="${BASE_VERSION}-devel+${SHORT_SHA}"
+  else
+    # dev / PR build: include a semver-safe branch identifier
+    RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
+    SAFE_BRANCH=$(echo "$RAW_BRANCH" | tr -c '0-9A-Za-z' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
+    STAMP="${BASE_VERSION}-dev.${SAFE_BRANCH}+${SHORT_SHA}"
+  fi
+  sed -i -E "0,/^__version__.*/s/^__version__.*/__version__ = \"${STAMP}\"/" riocli/bootstrap.py
+fi
+```
+
+- [ ] **Step 2: Shellcheck the script**
+
+Run: `shellcheck scripts/build-rio-appimage.sh || true`
+Expected: no new errors introduced by the added block (pre-existing warnings acceptable).
+
+- [ ] **Step 3: Local dry-run of the stamping logic (no full build)**
+
+Run:
+```bash
+cp riocli/bootstrap.py /tmp/bootstrap.bak
+CHANNEL=devel GITHUB_SHA=$(git rev-parse HEAD) bash -c '
+  BASE_VERSION=$(grep -m1 "^__version__" riocli/bootstrap.py | sed -E "s/.*\"([^\"]+)\".*/\1/")
+  SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
+  echo "would stamp: ${BASE_VERSION}-devel+${SHORT_SHA}"'
+cp /tmp/bootstrap.bak riocli/bootstrap.py
+```
+Expected: prints `would stamp: <current-version>-devel+<sha>` and restores the file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/build-rio-appimage.sh
+git commit -m "ci: stamp channel suffix into version for devel/dev AppImage builds"
+```
+
+---
+
+## Task 6: Upload AppImage + manifest to Azure Blob in the build script
+
+**Files:**
+- Modify: `scripts/build-rio-appimage.sh`
+
+- [ ] **Step 1: Append an upload stage at the end of the script (after `./appimagetool-x86_64.AppImage -n squashfs-root/`)**
+
+```bash
+# Upload the built AppImage to the channel's Azure Blob container.
+# Download stays anonymous (public-read); upload authenticates with a
+# write-scoped SAS token. Required env: CHANNEL, AZURE_STORAGE_ACCOUNT,
+# AZURE_SAS_TOKEN. dev/PR builds land under dev/<branch>/ and carry no
+# manifest (not an update channel).
+APPIMAGE_FILE=$(ls rio*.AppImage | head -n1)
+
+if [[ -n "${AZURE_STORAGE_ACCOUNT:-}" && -n "${AZURE_SAS_TOKEN:-}" ]]; then
+  if [[ "$CHANNEL" == "dev" ]]; then
+    RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
+    DEST="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/dev/${RAW_BRANCH}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
+    azcopy copy "${APPIMAGE_FILE}" "${DEST}"
+  else
+    SHA256=$(sha256sum "${APPIMAGE_FILE}" | cut -d' ' -f1)
+    VERSION=$(grep -m1 '^__version__' ../riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
+    cat > latest.json <<EOF
+{"version": "${VERSION}", "file": "${APPIMAGE_FILE}", "sha256": "${SHA256}"}
+EOF
+    BASE="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${CHANNEL}"
+    azcopy copy "${APPIMAGE_FILE}" "${BASE}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
+    azcopy copy "latest.json" "${BASE}/latest.json?${AZURE_SAS_TOKEN}"
+  fi
+else
+  echo "AZURE_STORAGE_ACCOUNT / AZURE_SAS_TOKEN not set — skipping blob upload"
+fi
+```
+
+Note: the script `cd scripts` earlier (line ~`cd scripts`), so `riocli/bootstrap.py` is referenced as `../riocli/bootstrap.py` here. Confirm the relative path against the `cd` in the script before running.
+
+- [ ] **Step 2: Ensure azcopy is available — add install near the `mc` install (top of script)**
+
+```bash
+# Install azcopy for Azure Blob uploads
+wget -q https://aka.ms/downloadazcopy-v10-linux -O azcopy.tar.gz
+tar -xzf azcopy.tar.gz --strip-components=1 --wildcards '*/azcopy'
+chmod +x azcopy
+export PATH="$PWD:$PATH"
+```
+
+- [ ] **Step 3: Shellcheck**
+
+Run: `shellcheck scripts/build-rio-appimage.sh || true`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/build-rio-appimage.sh
+git commit -m "ci: upload AppImage and latest.json manifest to Azure Blob"
+```
+
+---
+
+## Task 7: Update `upload-appimage.yml` (devel + dev channels)
+
+**Files:**
+- Modify: `.github/workflows/upload-appimage.yml`
+
+- [ ] **Step 1: Change triggers — drop `main`**
+
+```yaml
+on:
+  push:
+    branches:
+    - devel
+  pull_request:
+```
+
+- [ ] **Step 2: Set `CHANNEL` + Azure secrets on the build step**
+
+Replace the `Create AppImage` step's `env:` block:
+
+```yaml
+      - name: Create AppImage
+        run: ./scripts/build-rio-appimage.sh
+        shell: bash
+        env:
+          CHANNEL: ${{ github.event_name == 'pull_request' && 'dev' || 'devel' }}
+          MINIO_URL: ${{ secrets.MINIO_URL }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET: ${{ secrets.MINIO_SECRET }}
+          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          AZURE_SAS_TOKEN: ${{ secrets.AZURE_SAS_TOKEN }}
+```
+
+- [ ] **Step 3: Point the PR comment at the blob URL**
+
+Replace the body of the `Edit the last bot comment` and `Artifact Comment on PR` steps so the link is the blob path (the existing GitHub-Actions-artifact link is removed). Use:
+
+```yaml
+      - name: Comment blob link on PR
+        if: github.event_name == 'pull_request'
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          ACCOUNT="${{ secrets.AZURE_STORAGE_ACCOUNT }}"
+          FILE=$(ls scripts/rio*.AppImage | xargs -n1 basename | head -n1)
+          URL="https://${ACCOUNT}.blob.core.windows.net/dev/${BRANCH}/${FILE}"
+          gh pr comment "$PR_NUMBER" --edit-last -b "**🤖 PR AppImage:** [$FILE]($URL)" \
+            || gh pr comment "$PR_NUMBER" -b "**🤖 PR AppImage:** [$FILE]($URL)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+```
+
+Delete the now-obsolete `Edit the last bot comment`, `Delete existing bot comments`, and `Artifact Comment on PR` steps. The `Upload AppImage artifact` (`actions/upload-artifact`) step may be kept as a secondary or removed — keeping it adds a GitHub fallback at no cost; recommended to keep.
+
+- [ ] **Step 4: Validate workflow YAML**
+
+Run: `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/upload-appimage.yml'))"`
+Expected: no exception (valid YAML).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/upload-appimage.yml
+git commit -m "ci: upload devel/PR AppImages to Azure Blob, link blob URL on PRs"
+```
+
+---
+
+## Task 8: Update `release.yml` (release channel)
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add `CHANNEL=release` + Azure secrets to the semantic-release step env**
+
+Add to the `Run semantic-release` step's `env:` block (alongside the existing `MINIO_*`):
+
+```yaml
+          CHANNEL: release
+          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          AZURE_SAS_TOKEN: ${{ secrets.AZURE_SAS_TOKEN }}
+```
+
+(`.releaserc.json` already calls `build-rio-appimage.sh ${nextRelease.version}` as a `prepareCmd`; with `CHANNEL=release` it now also uploads the versioned AppImage + `latest.json` to the `release` container. The `@semantic-release/github` asset attach stays — GitHub Release remains the transition fallback.)
+
+- [ ] **Step 2: Validate workflow YAML**
+
+Run: `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+Expected: no exception.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: upload release AppImage to Azure Blob via semantic-release"
+```
+
+---
+
+## Task 9: Document required secrets + infra prerequisites
+
+**Files:**
+- Create: `docs/update-channels.md` (keep it out of CLAUDE.md to avoid bloat)
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# rio update channels
+
+`rio update` updates an AppImage install from Azure Blob Storage (public-read),
+keyed by the running binary's version:
+
+| Version pattern | Channel | Source |
+|---|---|---|
+| `X.Y.Z` | release | `https://<account>.blob.core.windows.net/release/latest.json` |
+| `X.Y.Z-devel+<sha>` | devel | `.../devel/latest.json` |
+| `X.Y.Z-dev.<branch>+<sha>` | none | not auto-updatable (dev build) |
+
+pip installs are unaffected — they continue to upgrade from PyPI.
+
+Override the blob base URL for testing: `RIO_APPIMAGE_BASE_URL=https://staging... rio update`.
+
+## CI prerequisites (GitHub secrets)
+
+- `AZURE_STORAGE_ACCOUNT` — storage account name (public-read containers `release`, `devel`, `dev`).
+- `AZURE_SAS_TOKEN` — write-scoped, container-scoped, time-bound SAS used by CI uploads.
+
+## Infra checklist (one-time)
+
+1. Provision the storage account in the OKD4 Prod subscription.
+2. Create containers `release` (permanent), `devel` (30d lifecycle), `dev` (15d lifecycle), all with anonymous blob read.
+3. Issue a write SAS; store it as `AZURE_SAS_TOKEN`. Set `AZURE_STORAGE_ACCOUNT`.
+4. Set `DEFAULT_ACCOUNT_URL` in `riocli/utils/appimage.py` to the real account before the first blob-aware release.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/update-channels.md
+git commit -m "docs: document rio update channels and CI secrets"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full unit suite: `uv run pytest tests/unit/ -v` — Expected: PASS
+- [ ] Lint/format: `uv run ruff check . && uv run ruff format --check .` — Expected: clean
+- [ ] Confirm no dangling reference: `grep -rn "update_appimage\|api.github.com/repos/rapyuta-robotics/rapyuta-io-cli/releases" riocli/` — Expected: no matches
+- [ ] Manual end-to-end (staging): build a devel AppImage, host `devel/latest.json` + file on a staging container, run `RIO_APPIMAGE_BASE_URL=<staging> ./rio update` from an older devel build, confirm it downloads, verifies sha256, and swaps the binary.
+
+## Notes for the implementer
+
+- **Backwards compat:** AppImages already in the field run the old GitHub-based updater. They keep working only because the GitHub Release asset is retained. The first blob-aware version must also ship as a normal GitHub Release so existing users can reach it; only after the field rolls past the last GitHub-only version may the GitHub asset attach be dropped (future cleanup, out of scope here).
+- **Account name:** `DEFAULT_ACCOUNT_URL` in `appimage.py` and `AZURE_STORAGE_ACCOUNT` in CI must match the real provisioned account (spec open question #1). `riocliartifacts` is a placeholder default.
+- **Do not touch** the pip path, `check_for_updates`, `pip_install_cli`, the MinIO build-input cache, or PyPI publishing.

--- a/docs/superpowers/specs/2026-06-14-rio-appimage-azure-blob-design.md
+++ b/docs/superpowers/specs/2026-06-14-rio-appimage-azure-blob-design.md
@@ -1,0 +1,182 @@
+# `rio update` — host AppImages on Azure Blob (kill GitHub rate-limit)
+
+- **Date:** 2026-06-14
+- **Status:** Design — pending review
+- **Owner:** amitsingh21
+- **Slack:** https://rapyuta-robotics.slack.com/archives/CBAP39MGD/p1781061285374049
+
+## Problem
+
+`rio update` fails for AppImage installs:
+
+```
+🎉 A newer version (10.5.0) is available.
+Do you want to update? [y/N]: y
+❌ Failed to update: Failed to retrieve the download URL for the latest AppImage
+```
+
+Root cause (confirmed in thread by Tom, U01672FEFPD):
+
+> "This must be rate limiting from Github on the office IP. The upgrade uses Github API to fetch the artifact. We have seen this happening before."
+
+`update_appimage()` (`riocli/utils/__init__.py:213`) calls `https://api.github.com/repos/rapyuta-robotics/rapyuta-io-cli/releases/latest`, then downloads the matched asset's `browser_download_url`. The **`api.github.com` call** is unauthenticated and shares the office-IP rate-limit budget; when exhausted, the assets lookup returns nothing and the download URL resolution fails.
+
+## Goals
+
+1. AppImage `rio update` downloads from **our Azure Blob storage**, not `api.github.com` — no shared GitHub rate limit.
+2. Channel-aware updates: a `release`-channel binary updates from the release channel; a `devel`-channel binary from devel.
+3. Per-branch PR AppImages hosted on our storage too (replace the GitHub-Actions-artifact PR-comment link).
+
+## Non-goals
+
+- **Do not** touch the pip/PyPI path. `is_pip_installation()` → `pip_install_cli()` stays exactly as-is; pip users keep using PyPI. Blob storage is queried *only* in the AppImage branch.
+- **Do not** migrate the MinIO build-input cache (appimagetool + python base AppImage). Separate concern, not user-facing, not rate-limiting anyone. Stays as-is.
+- **Do not** remove PyPI publishing (`pypi.yml`) or GitHub Release creation. Both kept (GitHub Release is the transition fallback — see Backwards Compatibility).
+
+## Current state (reference)
+
+| Trigger | Workflow | Output (today) |
+|---|---|---|
+| push `devel` | `upload-appimage.yml` | AppImage → GitHub Actions artifact (15d) |
+| push `main` | `upload-appimage.yml` + `release.yml` | GH artifact + semantic-release |
+| `release.yml` (semantic-release, main) | builds versioned AppImage | GitHub Release asset + changelog commit |
+| PR | `upload-appimage.yml` | GH Actions artifact + bot PR comment link |
+| GitHub release published | `pypi.yml` | PyPI publish |
+
+- Version check `check_for_updates()` (`utils/__init__.py:173`) → PyPI JSON. (Not rate-limited; PyPI is fine.)
+- Update dispatch `bootstrap.py:141`: pip → `pip_install_cli`; AppImage → `update_appimage`.
+- Azure precedent already in repo: `riocli/chart/util.py:12` `https://chartsbranch.blob.core.windows.net/charts-per-branch`, fetched with anonymous `requests.get()` (public-read). This design copies that access pattern.
+
+## Architecture
+
+### Storage account
+
+New dedicated Azure Storage account in the **OKD4 Prod subscription** (e.g. `riocliartifacts`). **Public-read containers, authenticated write** — anonymous GET for `rio update` (no creds shipped in the CLI), CI authenticates to upload.
+
+| Container | Contents | Written by | Lifecycle | `rio update` channel? |
+|---|---|---|---|---|
+| `release` | `rio-<ver>-x86_64.AppImage`, `latest.json` | `release.yml` | permanent | **yes (release)** |
+| `devel` | `rio-<ver>-x86_64.AppImage`, `latest.json` | `upload-appimage.yml` (push devel) | 30d auto-expire | **yes (devel)** |
+| `dev` | `<branch>/rio-<sha>-x86_64.AppImage` | `upload-appimage.yml` (PR) | 15d auto-expire | no — download host only |
+
+Separate containers (not path prefixes) so each can carry its own retention/lifecycle policy.
+
+### Channel identity — version suffix
+
+The build stamps `__version__` so an installed binary is self-describing; no extra bundled file.
+
+| Channel | `__version__` example | Container |
+|---|---|---|
+| release | `10.6.0` | `release` |
+| devel | `10.6.0-devel+<sha>` | `devel` |
+| dev/PR | `10.6.0-dev.<branch>+<sha>` | `dev` (not updatable) |
+
+`rio update` parses its own `__version__`:
+- pre-release token contains `devel` → devel channel.
+- pre-release token contains `dev.` → dev build → **not auto-updatable**; print a notice ("development build — rebuild from your branch or install a release").
+- otherwise → release channel.
+
+### `latest.json` manifest (release + devel only)
+
+```json
+{
+  "version": "10.6.0-devel+abc1234",
+  "file": "rio-10.6.0-devel+abc1234-x86_64.AppImage",
+  "sha256": "<hex>"
+}
+```
+
+CI regenerates and overwrites it on every build of that channel. The `dev` container has no manifest (per-branch, not a moving "latest").
+
+## Producer changes (CI)
+
+### `scripts/build-rio-appimage.sh`
+
+After the AppImage is built, add an upload stage driven by a `CHANNEL` env set by the calling workflow:
+
+1. Compute `sha256sum` of the built `rio-*.AppImage`.
+2. For `release`/`devel`: write `latest.json` (version, file, sha256).
+3. `azcopy copy` the AppImage (and, for release/devel, `latest.json`) into the channel container.
+   - `release`/`devel`: container root.
+   - `dev`: `dev/<branch>/`.
+4. Auth via a write-scoped **SAS token** (recommended) or account key, from a new GH secret.
+
+New GH secrets:
+- `AZURE_STORAGE_ACCOUNT` — account name.
+- `AZURE_SAS_TOKEN` — write-scoped SAS (container-scoped, short rotation) **or** `AZURE_STORAGE_KEY` account key.
+
+The build script already receives the version as `$1` (from `.releaserc.json` exec). For devel/dev (no semantic-release version), the script derives a version+suffix from `git` (`<base>-devel+<sha>` / `<base>-dev.<branch>+<sha>`).
+
+### `upload-appimage.yml`
+
+- **PR**: build → upload to `dev/<branch>/`. PR bot comment links to the blob URL instead of the GitHub-Actions-artifact run page. (Keep `upload-artifact` if desired as a secondary, or drop it.)
+- **push `devel`**: build → upload to `devel` + regenerate `devel/latest.json`.
+- **Remove `main`** from this workflow's triggers — `release.yml` owns main.
+- Pass `CHANNEL` + Azure secrets as env.
+
+### `release.yml` / `.releaserc.json`
+
+- semantic-release flow unchanged through changelog/version bump/GitHub Release/PyPI.
+- `build-rio-appimage.sh` (already a `prepareCmd` exec) gains the upload stage; called with `CHANNEL=release` → uploads versioned AppImage to `release` + regenerates `release/latest.json`.
+- **Keep** the `@semantic-release/github` asset attach (GitHub Release still carries the AppImage — transition fallback) and PyPI publish.
+
+## Consumer changes (CLI)
+
+### `update_appimage()` (`riocli/utils/__init__.py:213`)
+
+Replace the `api.github.com` lookup with blob fetch:
+
+1. Derive channel from `__version__`. If dev build → print notice, return (no auto-update).
+2. `GET https://<account>.blob.core.windows.net/<container>/latest.json` (anonymous).
+3. Download `https://<account>.blob.core.windows.net/<container>/<file>`.
+4. Verify `sha256` against the manifest; abort on mismatch.
+5. Swap the executable — **keep existing logic** (temp dir → chmod 755 → `os.remove(sys.executable)` → `move`, with the root-user warning on `OSError`).
+
+Account name: a module constant (mirrors `chart/util.py`'s `BRANCH_REPO_BASE`), overridable by env (e.g. `RIO_APPIMAGE_BASE_URL`) for testing/staging.
+
+### `check_for_updates()` (`riocli/utils/__init__.py:173`)
+
+Make installation-aware so the AppImage branch doesn't depend on PyPI for non-release channels:
+- pip install → PyPI JSON (unchanged).
+- AppImage → read `latest.json` for the binary's channel; compare `version` via `semver`.
+
+`bootstrap.py update` keeps its shape; the check + download just route by installation type and channel.
+
+### Fallback (optional, recommended for transition)
+
+If the blob `latest.json`/download is unreachable, fall back to the existing GitHub Release path so updates still work during rollout / blob outages.
+
+## Security / access model
+
+- **Download:** anonymous public-read containers. AppImages are already publicly downloadable on GitHub Releases, so no confidentiality change. No credentials shipped in the CLI.
+- **Upload:** CI only, via SAS token / account key in GH secrets. Prefer a container-scoped, write-only, time-bound SAS with a rotation reminder.
+- **Integrity:** sha256 in `latest.json`, verified client-side before swapping the executable.
+
+## Lifecycle / retention
+
+- `release`: permanent.
+- `devel`: blob lifecycle rule, delete after 30d.
+- `dev`: blob lifecycle rule, delete after 15d (matches today's GH-artifact retention).
+
+## Backwards compatibility / migration
+
+- AppImages **already in the field** (e.g. 10.5.0) run the old `update_appimage` that hits GitHub. They keep working **only while the GitHub Release path exists** — hence GitHub Release is kept. First `rio update` from an old binary still goes through GitHub, lands them on a blob-aware version; every update after that uses Azure.
+- The first blob-aware release must also be published as a normal GitHub Release so existing users can reach it.
+- No flag day; the two paths coexist. GitHub Release asset attach can be dropped only after the field has largely rolled past the last GitHub-only version (future cleanup).
+
+## Testing
+
+- **Unit (`tests/unit/`, no network):**
+  - channel-from-version parsing: `10.6.0` → release; `10.6.0-devel+x` → devel; `10.6.0-dev.feat+x` → dev/non-updatable.
+  - manifest URL construction per channel (mirror `test_chart_branch_util.py`).
+  - sha256 verify: pass on match, abort on mismatch.
+  - env override of the base URL.
+- **Manual / staging:** point the base-URL env at a staging container; run `rio update` from a built devel AppImage end to end.
+- **CI dry-run:** verify `build-rio-appimage.sh` upload stage against a throwaway container (SAS) before wiring secrets into the real workflows.
+
+## Open questions / follow-ups
+
+1. Final storage-account name + container names (`release`/`devel`/`dev` vs `release`/`devel`/`branches` — `devel`/`dev` are one letter apart; confirm acceptable).
+2. azcopy auth: write-scoped SAS (preferred) vs account key — infra preference + rotation policy.
+3. Exact retention days for `devel`/`dev` (proposed 30/15).
+4. Who provisions the account + public-access policy in OKD4 Prod (infra ticket).

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -6,8 +6,12 @@ keyed by the running binary's version string:
 | Version pattern | Channel | Manifest URL |
 |---|---|---|
 | `X.Y.Z` | `release` | `https://riocliartifacts.blob.core.windows.net/release/latest.json` |
-| `X.Y.Z-devel+<sha>` | `devel` | `https://riocliartifacts.blob.core.windows.net/devel/latest.json` |
-| `X.Y.Z-dev.<branch>+<sha>` | none | not auto-updatable (development build) |
+| `X.Y.Z+devel.<sha>` | `devel` | `https://riocliartifacts.blob.core.windows.net/devel/latest.json` |
+| `X.Y.Z+dev.<branch>.<sha>` | none | not auto-updatable (development build) |
+
+The channel marker lives in the version's local segment (after `+`) so the
+stamped version stays PEP 440-valid for `uv build`; channel detection reads
+the build-metadata segment.
 
 pip installs are unaffected — they continue to upgrade from PyPI via the existing `check_for_updates` / `pip_install_cli` path.
 

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -1,0 +1,65 @@
+# rio update channels
+
+`rio update` updates an AppImage install from Azure Blob Storage (public-read),
+keyed by the running binary's version string:
+
+| Version pattern | Channel | Manifest URL |
+|---|---|---|
+| `X.Y.Z` | `release` | `https://riocliartifacts.blob.core.windows.net/release/latest.json` |
+| `X.Y.Z-devel+<sha>` | `devel` | `https://riocliartifacts.blob.core.windows.net/devel/latest.json` |
+| `X.Y.Z-dev.<branch>+<sha>` | none | not auto-updatable (development build) |
+
+pip installs are unaffected — they continue to upgrade from PyPI via the existing `check_for_updates` / `pip_install_cli` path.
+
+## Overriding the base URL
+
+Set `RIO_APPIMAGE_BASE_URL` to redirect all manifest and download requests to a
+different host (useful for staging or local testing):
+
+```sh
+RIO_APPIMAGE_BASE_URL=https://staging.example.com rio update
+```
+
+The env var replaces the entire base; channel and filename are appended as usual
+(`<base>/<channel>/latest.json`, `<base>/<channel>/<file>`).
+
+## CI prerequisites (GitHub secrets)
+
+Two secrets must be set in the repository before the blob-upload workflows
+will function. **Do not put secret values in source files or commit history.**
+
+| Secret | Description |
+|---|---|
+| `AZURE_STORAGE_ACCOUNT` | Name of the Azure Storage account that hosts the public-read containers (`riocliartifacts`). Used by CI to construct the azcopy destination URL. |
+| `AZURE_SAS_TOKEN` | Write-scoped, container-scoped, time-bound Shared Access Signature. Passed to azcopy for uploads. Anonymous public reads do not use this token. **Expires 2027-06-14 — rotate before that date.** |
+
+These secrets are consumed by:
+
+- `.github/workflows/upload-appimage.yml` — devel pushes (`CHANNEL=devel`) and PR builds (`CHANNEL=dev`).
+- `.github/workflows/release.yml` — tagged releases (`CHANNEL=release`).
+
+## Azure Blob infra (provisioned)
+
+The storage account is live in **OKD4 Prod**:
+
+| Property | Value |
+|---|---|
+| Storage account | `riocliartifacts` |
+| Resource group | `rio-cli` |
+| Region | `japaneast` |
+| Base URL | `https://riocliartifacts.blob.core.windows.net` |
+
+### Containers
+
+| Container | Access | Lifecycle policy |
+|---|---|---|
+| `release` | Anonymous blob read (public) | Permanent — blobs are never auto-deleted |
+| `devel` | Anonymous blob read (public) | 30-day auto-delete |
+| `dev` | Anonymous blob read (public) | 15-day auto-delete |
+
+### SAS rotation reminder
+
+The write SAS stored in `AZURE_SAS_TOKEN` expires **2027-06-14**. Before that
+date, issue a new SAS with equivalent permissions (write, container-scoped) and
+update the GitHub secret. Uploads will fail silently after expiry because
+azcopy will receive a 403; rotate proactively.

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -51,10 +51,10 @@ from riocli.static_route import static_route
 from riocli.usergroup import usergroup
 from riocli.utils import (
     AliasedGroup,
+    appimage,
     check_for_updates,
     is_pip_installation,
     pip_install_cli,
-    update_appimage,
 )
 from riocli.vpn import vpn
 
@@ -127,21 +127,50 @@ def update(silent: bool) -> None:
     You can skip the confirmation prompt by using the --silent or
     --force or -f flag.
     """
-    available, latest = check_for_updates(__version__)
-    if not available:
+    if is_pip_installation():
+        available, latest = check_for_updates(__version__)
+        if not available:
+            click.secho("🎉 You are using the latest version", fg=Colors.GREEN)
+            return
+        click.secho(f"🎉 A newer version ({latest}) is available.", fg=Colors.GREEN)
+        if not silent:
+            _ = click.confirm("Do you want to update?", abort=True, default=False)
+        try:
+            _ = pip_install_cli(version=latest)
+        except Exception as e:
+            click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
+            raise SystemExit(1) from e
+        click.secho(f"{Symbols.SUCCESS} Update successful!", fg=Colors.GREEN)
+        return
+
+    # AppImage installation: update from our Azure Blob channel.
+    channel = appimage.channel_for_version(__version__)
+    if channel is None:
+        click.secho(
+            f"{Symbols.WARNING} This is a development build; auto-update is "
+            "disabled. Rebuild from your branch or install a release.",
+            fg=Colors.YELLOW,
+        )
+        return
+
+    try:
+        manifest = appimage.fetch_manifest(channel)
+    except Exception as e:
+        click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
+        raise SystemExit(1) from e
+
+    if not appimage.update_available(channel, manifest["version"], __version__):
         click.secho("🎉 You are using the latest version", fg=Colors.GREEN)
         return
 
-    click.secho(f"🎉 A newer version ({latest}) is available.", fg=Colors.GREEN)
-
+    click.secho(
+        f"🎉 A newer version ({manifest['version']}) is available.", fg=Colors.GREEN
+    )
     if not silent:
         _ = click.confirm("Do you want to update?", abort=True, default=False)
 
     try:
-        if is_pip_installation():
-            _ = pip_install_cli(version=latest)
-        else:
-            update_appimage(version=latest)
+        appimage.download_and_replace(channel, manifest)
     except Exception as e:
         click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
         raise SystemExit(1) from e

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -53,7 +53,6 @@ from riocli.utils import (
     AliasedGroup,
     appimage,
     check_for_updates,
-    is_pip_installation,
     pip_install_cli,
 )
 from riocli.vpn import vpn
@@ -127,7 +126,13 @@ def update(silent: bool) -> None:
     You can skip the confirmation prompt by using the --silent or
     --force or -f flag.
     """
-    if is_pip_installation():
+    # The AppImage runtime sets the APPIMAGE env var to the .AppImage path.
+    # Absent it, this is a pip install. (sys.executable is unreliable here:
+    # the AppImage's bundled interpreter path also contains "python", so the
+    # old "python" in sys.executable heuristic mis-classifies AppImages.)
+    appimage_path = os.environ.get("APPIMAGE")
+
+    if not appimage_path:
         available, latest = check_for_updates(__version__)
         if not available:
             click.secho("🎉 You are using the latest version", fg=Colors.GREEN)
@@ -143,7 +148,9 @@ def update(silent: bool) -> None:
         click.secho(f"{Symbols.SUCCESS} Update successful!", fg=Colors.GREEN)
         return
 
-    # AppImage installation: update from our Azure Blob channel.
+    # AppImage installation: update from our Azure Blob channel, replacing the
+    # AppImage file itself (target=APPIMAGE, not sys.executable — that is the
+    # bundled interpreter inside the mounted AppImage).
     channel = appimage.channel_for_version(__version__)
     if channel is None:
         click.secho(
@@ -169,7 +176,7 @@ def update(silent: bool) -> None:
         _ = click.confirm("Do you want to update?", abort=True, default=False)
 
     try:
-        appimage.download_and_replace(channel, manifest)
+        appimage.download_and_replace(channel, manifest, target=appimage_path)
     except Exception as e:
         click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
         raise SystemExit(1) from e

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -155,17 +155,16 @@ def update(silent: bool) -> None:
 
     try:
         manifest = appimage.fetch_manifest(channel)
+        version = manifest["version"]
     except Exception as e:
         click.secho(f"{Symbols.ERROR} Failed to update: {e}", fg=Colors.RED)
         raise SystemExit(1) from e
 
-    if not appimage.update_available(channel, manifest["version"], __version__):
+    if not appimage.update_available(channel, version, __version__):
         click.secho("🎉 You are using the latest version", fg=Colors.GREEN)
         return
 
-    click.secho(
-        f"🎉 A newer version ({manifest['version']}) is available.", fg=Colors.GREEN
-    )
+    click.secho(f"🎉 A newer version ({version}) is available.", fg=Colors.GREEN)
     if not silent:
         _ = click.confirm("Do you want to update?", abort=True, default=False)
 

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -151,7 +151,13 @@ def update(silent: bool) -> None:
     # AppImage installation: update from our Azure Blob channel, replacing the
     # AppImage file itself (target=APPIMAGE, not sys.executable — that is the
     # bundled interpreter inside the mounted AppImage).
-    channel = appimage.channel_for_version(__version__)
+    try:
+        channel = appimage.channel_for_version(__version__)
+    except ValueError as e:
+        click.secho(
+            f"{Symbols.ERROR} Cannot determine update channel: {e}", fg=Colors.RED
+        )
+        raise SystemExit(1) from e
     if channel is None:
         click.secho(
             f"{Symbols.WARNING} This is a development build; auto-update is "

--- a/riocli/utils/__init__.py
+++ b/riocli/utils/__init__.py
@@ -162,10 +162,6 @@ def print_separator(color: str = "blue"):
     click.secho(" " * col, bg=color)
 
 
-def is_pip_installation() -> bool:
-    return "python" in sys.executable
-
-
 def check_for_updates(current_version: str) -> tuple[bool, str]:
     try:
         package_info = requests.get("https://pypi.org/pypi/rapyuta-io-cli/json").json()

--- a/riocli/utils/__init__.py
+++ b/riocli/utils/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 import random
 import shlex
 import string
@@ -20,9 +19,7 @@ import subprocess
 import sys
 import uuid
 from collections.abc import Iterable
-from pathlib import Path
-from shutil import get_terminal_size, move
-from tempfile import TemporaryDirectory
+from shutil import get_terminal_size
 from typing import Any
 from uuid import UUID
 
@@ -31,10 +28,9 @@ import requests
 import semver
 import yaml
 from click_help_colors import HelpColorsGroup
-from munch import munchify
 from tabulate import tabulate
 
-from riocli.constants import Colors, Symbols
+from riocli.constants import Colors
 from riocli.utils.alias import AliasedGroup as AliasedGroup
 
 
@@ -208,57 +204,6 @@ def pip_install_cli(
         command.append("--force-reinstall")
 
     return subprocess.run(command, check=True)
-
-
-def update_appimage(version: str):
-    """
-    Updates the AppImage locally
-    """
-    if not version:
-        raise ValueError("version cannot be empty")
-
-    # URL to get the latest release metadata
-    url = "https://api.github.com/repos/rapyuta-robotics/rapyuta-io-cli/releases/latest"
-
-    try:
-        response = requests.get(url)
-        data = munchify(response.json())
-    except Exception as e:
-        click.secho(f"Failed to fetch release info: {e}", fg=Colors.RED)
-        raise SystemExit(1) from e
-
-    asset = None
-    for a in data.get("assets", []):
-        if "AppImage" in a.name and version in a.name:
-            asset = a
-            break
-
-    if asset is None:
-        raise Exception("Failed to retrieve the download URL for the latest AppImage")
-
-    # Download the AppImage
-    try:
-        response = requests.get(asset.browser_download_url)
-    except Exception as e:
-        raise Exception(f"Failed to download the new version: {e}")
-
-    with TemporaryDirectory() as tmp:
-        # Save the binary in a temp dir
-        save_to = Path(tmp) / "rio"
-        save_to.write_bytes(response.content)
-        os.chmod(save_to, 0o755)
-        # Now replace the current executable with the new file
-        try:
-            os.remove(sys.executable)
-            move(save_to, sys.executable)
-        except OSError as e:
-            click.secho(
-                f"{Symbols.WARNING} Please consider running as a root user.",
-                fg=Colors.YELLOW,
-            )
-            raise e
-        except Exception as e:
-            raise e
 
 
 def generate_short_guid() -> str:

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -106,9 +106,11 @@ def download_and_replace(channel: str, manifest: dict, target: str | None = None
     target_path = Path(target)
     fd, tmp_path = tempfile.mkstemp(dir=target_path.parent, prefix=".rio-update-")
     try:
-        os.write(fd, content)
-        os.fchmod(fd, 0o755)
-        os.close(fd)
+        # os.fdopen takes ownership of fd; f.write loops until all bytes are
+        # written (os.write may short-write on a multi-MB binary).
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+        os.chmod(tmp_path, 0o755)
         os.replace(tmp_path, target)
     except OSError as e:
         try:

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -26,9 +26,8 @@ from riocli.constants import Colors, Symbols
 CHANNEL_RELEASE = "release"
 CHANNEL_DEVEL = "devel"
 
-# Public-read Azure Blob account that hosts the rio AppImages.
-# NOTE: confirm the final account name with infra before the first
-# blob-aware release (spec open question #1). Overridable via env for
+# Public-read Azure Blob account (OKD4 Prod) hosting the rio AppImages.
+# Containers: release / devel / dev. Override via RIO_APPIMAGE_BASE_URL for
 # staging/testing.
 DEFAULT_ACCOUNT_URL = "https://riocliartifacts.blob.core.windows.net"
 

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -60,3 +60,15 @@ def manifest_url(channel: str) -> str:
 
 def appimage_url(channel: str, filename: str) -> str:
     return f"{base_url()}/{channel}/{filename}"
+
+
+def update_available(channel: str, remote_version: str, current_version: str) -> bool:
+    """Whether ``remote_version`` should replace ``current_version``.
+
+    Release channel uses semver precedence (no downgrades). Devel builds
+    share a base version and differ only by ignored +build metadata, so
+    compare the full string for any change.
+    """
+    if channel == CHANNEL_DEVEL:
+        return remote_version != current_version
+    return semver.Version.parse(remote_version).compare(current_version) > 0

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -109,21 +109,26 @@ def download_and_replace(channel: str, manifest: dict, target: str | None = None
         raise Exception("Checksum mismatch for the downloaded AppImage")
 
     target_path = Path(target)
-    fd, tmp_path = tempfile.mkstemp(dir=target_path.parent, prefix=".rio-update-")
+    tmp_path = None
     try:
+        # Create the temp file in the target's own directory so os.replace is
+        # an atomic same-filesystem rename. mkstemp is inside the try so a
+        # permission error here still surfaces the root-user hint below.
+        fd, tmp_path = tempfile.mkstemp(dir=target_path.parent, prefix=".rio-update-")
         # os.fdopen takes ownership of fd; f.write loops until all bytes are
         # written (os.write may short-write on a multi-MB binary).
         with os.fdopen(fd, "wb") as f:
             f.write(content)
         os.chmod(tmp_path, 0o755)
         os.replace(tmp_path, target)
-    except OSError as e:
-        try:
-            os.unlink(tmp_path)
-        except FileNotFoundError:
-            pass
+    except OSError:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
         click.secho(
             f"{Symbols.WARNING} Please consider running as a root user.",
             fg=Colors.YELLOW,
         )
-        raise e
+        raise

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -72,3 +72,40 @@ def update_available(channel: str, remote_version: str, current_version: str) ->
     if channel == CHANNEL_DEVEL:
         return remote_version != current_version
     return semver.Version.parse(remote_version).compare(current_version) > 0
+
+
+def fetch_manifest(channel: str) -> dict:
+    """Fetch and parse the channel's latest.json (anonymous GET)."""
+    resp = requests.get(manifest_url(channel))
+    resp.raise_for_status()
+    return resp.json()
+
+
+def download_and_replace(channel: str, manifest: dict, target: str | None = None) -> None:
+    """Download the AppImage named in the manifest, verify its sha256,
+    then atomically replace ``target`` (defaults to the running executable).
+    """
+    if target is None:
+        target = sys.executable
+
+    resp = requests.get(appimage_url(channel, manifest["file"]))
+    resp.raise_for_status()
+    content = resp.content
+
+    expected = manifest.get("sha256")
+    if expected and sha256(content).hexdigest() != expected:
+        raise Exception("Checksum mismatch for the downloaded AppImage")
+
+    with TemporaryDirectory() as tmp:
+        save_to = Path(tmp) / "rio"
+        save_to.write_bytes(content)
+        os.chmod(save_to, 0o755)
+        try:
+            os.remove(target)
+            move(save_to, target)
+        except OSError as e:
+            click.secho(
+                f"{Symbols.WARNING} Please consider running as a root user.",
+                fg=Colors.YELLOW,
+            )
+            raise e

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -82,53 +82,84 @@ def update_available(channel: str, remote_version: str, current_version: str) ->
     return semver.Version.parse(remote_version).compare(current_version) > 0
 
 
+_REQUIRED_MANIFEST_KEYS = ("version", "file", "sha256")
+
+
 def fetch_manifest(channel: str) -> dict:
-    """Fetch and parse the channel's latest.json (anonymous GET)."""
+    """Fetch, parse and validate the channel's latest.json (anonymous GET).
+
+    Raises ValueError with an actionable message if the manifest is not a
+    JSON object carrying the required keys, so callers get a clear error
+    instead of a downstream KeyError/TypeError.
+    """
     resp = requests.get(manifest_url(channel), timeout=10)
     resp.raise_for_status()
-    return resp.json()
+    manifest = resp.json()
+    if not isinstance(manifest, dict) or not all(
+        k in manifest for k in _REQUIRED_MANIFEST_KEYS
+    ):
+        raise ValueError(
+            f"Malformed manifest for channel {channel!r}: "
+            f"expected a JSON object with keys {_REQUIRED_MANIFEST_KEYS}"
+        )
+    return manifest
+
+
+def _unlink_quietly(path: str | None) -> None:
+    if path is not None:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
 
 
 def download_and_replace(channel: str, manifest: dict, target: str | None = None) -> None:
-    """Download the AppImage named in the manifest, verify its sha256,
-    then atomically replace ``target`` (defaults to the running executable).
+    """Stream the AppImage named in the manifest into a sibling temp file,
+    verify its sha256, then atomically replace ``target``.
+
+    ``target`` defaults to the AppImage path (``APPIMAGE`` env var, set by the
+    AppImage runtime) and falls back to the running interpreter.
     """
     if target is None:
-        target = sys.executable
-
-    resp = requests.get(appimage_url(channel, manifest["file"]), timeout=(10, 300))
-    resp.raise_for_status()
-    content = resp.content
+        target = os.environ.get("APPIMAGE") or sys.executable
 
     expected = manifest.get("sha256")
     if not expected:
         raise ValueError(
             "Manifest missing 'sha256' — refusing to install unverified binary"
         )
-    if sha256(content).hexdigest() != expected:
-        raise Exception("Checksum mismatch for the downloaded AppImage")
 
     target_path = Path(target)
     tmp_path = None
+    digest = sha256()
     try:
-        # Create the temp file in the target's own directory so os.replace is
-        # an atomic same-filesystem rename. mkstemp is inside the try so a
-        # permission error here still surfaces the root-user hint below.
+        # Temp file in the target's own directory so os.replace is an atomic
+        # same-filesystem rename. Stream the download (AppImages are tens of
+        # MB) and hash incrementally to bound peak memory.
         fd, tmp_path = tempfile.mkstemp(dir=target_path.parent, prefix=".rio-update-")
-        # os.fdopen takes ownership of fd; f.write loops until all bytes are
-        # written (os.write may short-write on a multi-MB binary).
         with os.fdopen(fd, "wb") as f:
-            f.write(content)
+            with requests.get(
+                appimage_url(channel, manifest["file"]),
+                timeout=(10, 300),
+                stream=True,
+            ) as resp:
+                resp.raise_for_status()
+                for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                    f.write(chunk)
+                    digest.update(chunk)
+        if digest.hexdigest() != expected:
+            raise ValueError("Checksum mismatch for the downloaded AppImage")
         os.chmod(tmp_path, 0o755)
         os.replace(tmp_path, target)
     except OSError:
-        if tmp_path is not None:
-            try:
-                os.unlink(tmp_path)
-            except FileNotFoundError:
-                pass
+        _unlink_quietly(tmp_path)
         click.secho(
             f"{Symbols.WARNING} Please consider running as a root user.",
             fg=Colors.YELLOW,
         )
+        raise
+    except Exception:
+        # Any non-OS failure (checksum mismatch, network error) must still
+        # clean up the partial temp file and leave the original untouched.
+        _unlink_quietly(tmp_path)
         raise

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 import os
 import sys
+import tempfile
 from hashlib import sha256
 from pathlib import Path
-from shutil import move
-from tempfile import TemporaryDirectory
 
 import click
 import requests
@@ -46,7 +45,10 @@ def channel_for_version(version: str) -> str | None:
     Anything else (``dev.<branch>``, ``rc.N``, etc.) is not an
     auto-updatable channel and returns None.
     """
-    pre = semver.Version.parse(version).prerelease
+    try:
+        pre = semver.Version.parse(version).prerelease
+    except ValueError as e:
+        raise ValueError(f"Invalid version string: {version!r}") from e
     if pre is None:
         return CHANNEL_RELEASE
     if pre == CHANNEL_DEVEL or pre.startswith(f"{CHANNEL_DEVEL}."):
@@ -67,16 +69,18 @@ def update_available(channel: str, remote_version: str, current_version: str) ->
 
     Release channel uses semver precedence (no downgrades). Devel builds
     share a base version and differ only by ignored +build metadata, so
-    compare the full string for any change.
+    compare the full string for any change (but never downgrade base version).
     """
     if channel == CHANNEL_DEVEL:
+        if semver.Version.parse(remote_version).compare(current_version) < 0:
+            return False
         return remote_version != current_version
     return semver.Version.parse(remote_version).compare(current_version) > 0
 
 
 def fetch_manifest(channel: str) -> dict:
     """Fetch and parse the channel's latest.json (anonymous GET)."""
-    resp = requests.get(manifest_url(channel))
+    resp = requests.get(manifest_url(channel), timeout=10)
     resp.raise_for_status()
     return resp.json()
 
@@ -88,24 +92,32 @@ def download_and_replace(channel: str, manifest: dict, target: str | None = None
     if target is None:
         target = sys.executable
 
-    resp = requests.get(appimage_url(channel, manifest["file"]))
+    resp = requests.get(appimage_url(channel, manifest["file"]), timeout=(10, 300))
     resp.raise_for_status()
     content = resp.content
 
     expected = manifest.get("sha256")
-    if expected and sha256(content).hexdigest() != expected:
+    if not expected:
+        raise ValueError(
+            "Manifest missing 'sha256' — refusing to install unverified binary"
+        )
+    if sha256(content).hexdigest() != expected:
         raise Exception("Checksum mismatch for the downloaded AppImage")
 
-    with TemporaryDirectory() as tmp:
-        save_to = Path(tmp) / "rio"
-        save_to.write_bytes(content)
-        os.chmod(save_to, 0o755)
+    target_path = Path(target)
+    fd, tmp_path = tempfile.mkstemp(dir=target_path.parent, prefix=".rio-update-")
+    try:
+        os.write(fd, content)
+        os.fchmod(fd, 0o755)
+        os.close(fd)
+        os.replace(tmp_path, target)
+    except OSError as e:
         try:
-            os.remove(target)
-            move(save_to, target)
-        except OSError as e:
-            click.secho(
-                f"{Symbols.WARNING} Please consider running as a root user.",
-                fg=Colors.YELLOW,
-            )
-            raise e
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        click.secho(
+            f"{Symbols.WARNING} Please consider running as a root user.",
+            fg=Colors.YELLOW,
+        )
+        raise e

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -40,17 +40,22 @@ def base_url() -> str:
 def channel_for_version(version: str) -> str | None:
     """Map a CLI version to its update channel.
 
-    Plain semver -> release. A ``devel``/``devel.N`` prerelease -> devel.
-    Anything else (``dev.<branch>``, ``rc.N``, etc.) is not an
-    auto-updatable channel and returns None.
+    The channel is carried in the version's local/build segment so the
+    stamped version stays PEP 440-valid for ``uv build`` (a semver-style
+    ``-prerelease`` would fail the wheel build). Examples:
+
+    - ``10.6.0`` (no build metadata) -> release
+    - ``10.6.0+devel.<sha>`` -> devel
+    - ``10.6.0+dev.<branch>.<sha>`` (or any other build label) -> None
+      (development build, not auto-updatable)
     """
     try:
-        pre = semver.Version.parse(version).prerelease
+        build = semver.Version.parse(version).build
     except ValueError as e:
         raise ValueError(f"Invalid version string: {version!r}") from e
-    if pre is None:
+    if build is None:
         return CHANNEL_RELEASE
-    if pre == CHANNEL_DEVEL or pre.startswith(f"{CHANNEL_DEVEL}."):
+    if build == CHANNEL_DEVEL or build.startswith(f"{CHANNEL_DEVEL}."):
         return CHANNEL_DEVEL
     return None
 

--- a/riocli/utils/appimage.py
+++ b/riocli/utils/appimage.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+from hashlib import sha256
+from pathlib import Path
+from shutil import move
+from tempfile import TemporaryDirectory
+
+import click
+import requests
+import semver
+
+from riocli.constants import Colors, Symbols
+
+CHANNEL_RELEASE = "release"
+CHANNEL_DEVEL = "devel"
+
+# Public-read Azure Blob account that hosts the rio AppImages.
+# NOTE: confirm the final account name with infra before the first
+# blob-aware release (spec open question #1). Overridable via env for
+# staging/testing.
+DEFAULT_ACCOUNT_URL = "https://riocliartifacts.blob.core.windows.net"
+
+
+def base_url() -> str:
+    """Base URL of the AppImage blob account (env-overridable)."""
+    return os.environ.get("RIO_APPIMAGE_BASE_URL", DEFAULT_ACCOUNT_URL)
+
+
+def channel_for_version(version: str) -> str | None:
+    """Map a CLI version to its update channel.
+
+    Plain semver -> release. A ``devel``/``devel.N`` prerelease -> devel.
+    Anything else (``dev.<branch>``, ``rc.N``, etc.) is not an
+    auto-updatable channel and returns None.
+    """
+    pre = semver.Version.parse(version).prerelease
+    if pre is None:
+        return CHANNEL_RELEASE
+    if pre == CHANNEL_DEVEL or pre.startswith(f"{CHANNEL_DEVEL}."):
+        return CHANNEL_DEVEL
+    return None
+
+
+def manifest_url(channel: str) -> str:
+    return f"{base_url()}/{channel}/latest.json"
+
+
+def appimage_url(channel: str, filename: str) -> str:
+    return f"{base_url()}/{channel}/{filename}"

--- a/scripts/build-rio-appimage.sh
+++ b/scripts/build-rio-appimage.sh
@@ -100,3 +100,30 @@ fi
 
 # Building AppImage
 ./appimagetool-x86_64.AppImage -n squashfs-root/
+
+# Upload the built AppImage to the channel's Azure Blob container.
+# Download stays anonymous (public-read); upload authenticates with a
+# write-scoped SAS token. Required env: CHANNEL, AZURE_STORAGE_ACCOUNT,
+# AZURE_SAS_TOKEN. dev/PR builds land under dev/<branch>/ and carry no
+# manifest (not an update channel).
+# cwd = scripts/ here, so riocli/bootstrap.py is at ../riocli/bootstrap.py
+APPIMAGE_FILE=$(find . -maxdepth 1 -name 'rio*.AppImage' | head -n1 | sed 's|^\./||')
+
+if [[ -n "${AZURE_STORAGE_ACCOUNT:-}" && -n "${AZURE_SAS_TOKEN:-}" ]]; then
+  if [[ "$CHANNEL" == "dev" ]]; then
+    RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
+    DEST="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/dev/${RAW_BRANCH}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
+    azcopy copy "${APPIMAGE_FILE}" "${DEST}"
+  else
+    SHA256=$(sha256sum "${APPIMAGE_FILE}" | cut -d' ' -f1)
+    VERSION=$(grep -m1 '^__version__' ../riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
+    cat > latest.json <<EOF
+{"version": "${VERSION}", "file": "${APPIMAGE_FILE}", "sha256": "${SHA256}"}
+EOF
+    BASE="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${CHANNEL}"
+    azcopy copy "${APPIMAGE_FILE}" "${BASE}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
+    azcopy copy "latest.json" "${BASE}/latest.json?${AZURE_SAS_TOKEN}"
+  fi
+else
+  echo "AZURE_STORAGE_ACCOUNT / AZURE_SAS_TOKEN not set — skipping blob upload"
+fi

--- a/scripts/build-rio-appimage.sh
+++ b/scripts/build-rio-appimage.sh
@@ -27,6 +27,7 @@ export PATH="$PWD:$PATH"
 # builds are versioned upstream by bump-version.sh and are left as-is.
 # cwd = repo root here, so riocli/bootstrap.py has no leading ../
 CHANNEL="${CHANNEL:-dev}"
+RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
 if [[ "$CHANNEL" != "release" ]]; then
   BASE_VERSION=$(grep -m1 '^__version__' riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
   SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
@@ -34,7 +35,6 @@ if [[ "$CHANNEL" != "release" ]]; then
     STAMP="${BASE_VERSION}-devel+${SHORT_SHA}"
   else
     # dev / PR build: include a semver-safe branch identifier
-    RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
     SAFE_BRANCH=$(echo "$RAW_BRANCH" | tr -c '0-9A-Za-z' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
     STAMP="${BASE_VERSION}-dev.${SAFE_BRANCH}+${SHORT_SHA}"
   fi
@@ -101,19 +101,21 @@ fi
 # Building AppImage
 ./appimagetool-x86_64.AppImage -n squashfs-root/
 
+APPIMAGE_FILE=$(find . -maxdepth 1 -name 'rio*.AppImage' | head -n1 | sed 's|^\./||')
+[[ -n "$APPIMAGE_FILE" ]] || { echo "ERROR: no rio*.AppImage found in scripts/"; exit 1; }
+
 # Upload the built AppImage to the channel's Azure Blob container.
 # Download stays anonymous (public-read); upload authenticates with a
 # write-scoped SAS token. Required env: CHANNEL, AZURE_STORAGE_ACCOUNT,
-# AZURE_SAS_TOKEN. dev/PR builds land under dev/<branch>/ and carry no
-# manifest (not an update channel).
-# cwd = scripts/ here, so riocli/bootstrap.py is at ../riocli/bootstrap.py
-APPIMAGE_FILE=$(find . -maxdepth 1 -name 'rio*.AppImage' | head -n1 | sed 's|^\./||')
-
+# AZURE_SAS_TOKEN.
+# dev builds  -> dev/<branch>/<file>, no manifest (not an update channel)
+# devel/release builds -> <channel>/<file> + latest.json manifest
 if [[ -n "${AZURE_STORAGE_ACCOUNT:-}" && -n "${AZURE_SAS_TOKEN:-}" ]]; then
+  # silence trace: SAS token is in the URL
+  set +x
   if [[ "$CHANNEL" == "dev" ]]; then
-    RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
     DEST="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/dev/${RAW_BRANCH}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
-    azcopy copy "${APPIMAGE_FILE}" "${DEST}"
+    azcopy copy "${APPIMAGE_FILE}" "${DEST}" --overwrite=true
   else
     SHA256=$(sha256sum "${APPIMAGE_FILE}" | cut -d' ' -f1)
     VERSION=$(grep -m1 '^__version__' ../riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
@@ -121,9 +123,10 @@ if [[ -n "${AZURE_STORAGE_ACCOUNT:-}" && -n "${AZURE_SAS_TOKEN:-}" ]]; then
 {"version": "${VERSION}", "file": "${APPIMAGE_FILE}", "sha256": "${SHA256}"}
 EOF
     BASE="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${CHANNEL}"
-    azcopy copy "${APPIMAGE_FILE}" "${BASE}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
-    azcopy copy "latest.json" "${BASE}/latest.json?${AZURE_SAS_TOKEN}"
+    azcopy copy "${APPIMAGE_FILE}" "${BASE}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}" --overwrite=true
+    azcopy copy "latest.json" "${BASE}/latest.json?${AZURE_SAS_TOKEN}" --overwrite=true
   fi
+  set -x
 else
   echo "AZURE_STORAGE_ACCOUNT / AZURE_SAS_TOKEN not set — skipping blob upload"
 fi

--- a/scripts/build-rio-appimage.sh
+++ b/scripts/build-rio-appimage.sh
@@ -14,6 +14,33 @@ chmod +x mc
 ./mc cp -r local/appimages/python3.13.7-cp313-cp313-manylinux_2_28_x86_64.AppImage scripts/
 chmod +x scripts/*.AppImage
 
+# Install azcopy for Azure Blob uploads (used later in the upload stage).
+# Export PATH now (cwd = repo root) so azcopy stays on PATH after cd scripts.
+wget -q https://aka.ms/downloadazcopy-v10-linux -O azcopy.tar.gz
+tar -xzf azcopy.tar.gz --strip-components=1 --wildcards '*/azcopy'
+chmod +x azcopy
+export PATH="$PWD:$PATH"
+
+# Stamp a channel suffix into __version__ for non-release builds so the
+# installed AppImage knows which Azure Blob container to update from.
+# CHANNEL is set by the calling workflow (release|devel|dev). Release
+# builds are versioned upstream by bump-version.sh and are left as-is.
+# cwd = repo root here, so riocli/bootstrap.py has no leading ../
+CHANNEL="${CHANNEL:-dev}"
+if [[ "$CHANNEL" != "release" ]]; then
+  BASE_VERSION=$(grep -m1 '^__version__' riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
+  SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
+  if [[ "$CHANNEL" == "devel" ]]; then
+    STAMP="${BASE_VERSION}-devel+${SHORT_SHA}"
+  else
+    # dev / PR build: include a semver-safe branch identifier
+    RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
+    SAFE_BRANCH=$(echo "$RAW_BRANCH" | tr -c '0-9A-Za-z' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
+    STAMP="${BASE_VERSION}-dev.${SAFE_BRANCH}+${SHORT_SHA}"
+  fi
+  sed -i -E "0,/^__version__.*/s/^__version__.*/__version__ = \"${STAMP}\"/" riocli/bootstrap.py
+fi
+
 # Creating rio-cli wheel
 uv build
 cp dist/rapyuta_io_cli-*.whl scripts/

--- a/scripts/build-rio-appimage.sh
+++ b/scripts/build-rio-appimage.sh
@@ -28,6 +28,10 @@ export PATH="$PWD:$PATH"
 # cwd = repo root here, so riocli/bootstrap.py has no leading ../
 CHANNEL="${CHANNEL:-dev}"
 RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
+# Sanitize the branch to a portable identifier (no slashes/special chars) used
+# in BOTH the version stamp and the dev blob path. upload-appimage.yml applies
+# the same transform to the PR-comment URL so the link matches the upload.
+SAFE_BRANCH=$(echo "$RAW_BRANCH" | tr -c '0-9A-Za-z' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
 if [[ "$CHANNEL" != "release" ]]; then
   BASE_VERSION=$(grep -m1 '^__version__' riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
   SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
@@ -38,8 +42,7 @@ if [[ "$CHANNEL" != "release" ]]; then
   if [[ "$CHANNEL" == "devel" ]]; then
     STAMP="${BASE_VERSION}+devel.${SHORT_SHA}"
   else
-    # dev / PR build: include a local-version-safe branch identifier
-    SAFE_BRANCH=$(echo "$RAW_BRANCH" | tr -c '0-9A-Za-z' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
+    # dev / PR build: include the sanitized branch identifier
     STAMP="${BASE_VERSION}+dev.${SAFE_BRANCH}.${SHORT_SHA}"
   fi
   sed -i -E "0,/^__version__.*/s/^__version__.*/__version__ = \"${STAMP}\"/" riocli/bootstrap.py
@@ -112,13 +115,13 @@ APPIMAGE_FILE=$(find . -maxdepth 1 -name 'rio*.AppImage' | head -n1 | sed 's|^\.
 # Download stays anonymous (public-read); upload authenticates with a
 # write-scoped SAS token. Required env: CHANNEL, AZURE_STORAGE_ACCOUNT,
 # AZURE_SAS_TOKEN.
-# dev builds  -> dev/<branch>/<file>, no manifest (not an update channel)
+# dev builds  -> dev/<safe-branch>/<file>, no manifest (not an update channel)
 # devel/release builds -> <channel>/<file> + latest.json manifest
 if [[ -n "${AZURE_STORAGE_ACCOUNT:-}" && -n "${AZURE_SAS_TOKEN:-}" ]]; then
   # silence trace: SAS token is in the URL
   set +x
   if [[ "$CHANNEL" == "dev" ]]; then
-    DEST="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/dev/${RAW_BRANCH}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
+    DEST="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/dev/${SAFE_BRANCH}/${APPIMAGE_FILE}?${AZURE_SAS_TOKEN}"
     azcopy copy "${APPIMAGE_FILE}" "${DEST}" --overwrite=true
   else
     SHA256=$(sha256sum "${APPIMAGE_FILE}" | cut -d' ' -f1)

--- a/scripts/build-rio-appimage.sh
+++ b/scripts/build-rio-appimage.sh
@@ -31,12 +31,16 @@ RAW_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
 if [[ "$CHANNEL" != "release" ]]; then
   BASE_VERSION=$(grep -m1 '^__version__' riocli/bootstrap.py | sed -E 's/.*"([^"]+)".*/\1/')
   SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
+  # The channel marker goes in the PEP 440 local-version segment (after +)
+  # so `uv build` accepts it; a semver-style -prerelease (e.g. -dev.x) is
+  # NOT PEP 440-valid and fails the wheel build. semver still parses these
+  # (the segment is build metadata), and channel_for_version reads .build.
   if [[ "$CHANNEL" == "devel" ]]; then
-    STAMP="${BASE_VERSION}-devel+${SHORT_SHA}"
+    STAMP="${BASE_VERSION}+devel.${SHORT_SHA}"
   else
-    # dev / PR build: include a semver-safe branch identifier
+    # dev / PR build: include a local-version-safe branch identifier
     SAFE_BRANCH=$(echo "$RAW_BRANCH" | tr -c '0-9A-Za-z' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
-    STAMP="${BASE_VERSION}-dev.${SAFE_BRANCH}+${SHORT_SHA}"
+    STAMP="${BASE_VERSION}+dev.${SAFE_BRANCH}.${SHORT_SHA}"
   fi
   sed -i -E "0,/^__version__.*/s/^__version__.*/__version__ = \"${STAMP}\"/" riocli/bootstrap.py
 fi

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from riocli.bootstrap import cli
+
+
+def test_update_devel_appimage_uses_blob():
+    """A devel AppImage runs the blob path, not the GitHub path."""
+    manifest = {
+        "version": "10.9.9-devel+newsha",
+        "file": "rio-10.9.9-devel+newsha-x86_64.AppImage",
+        "sha256": "x",
+    }
+    with (
+        patch("riocli.bootstrap.__version__", "10.6.0-devel+oldsha"),
+        patch("riocli.bootstrap.is_pip_installation", return_value=False),
+        patch("riocli.bootstrap.appimage.fetch_manifest", return_value=manifest) as fm,
+        patch("riocli.bootstrap.appimage.download_and_replace") as dr,
+    ):
+        result = CliRunner().invoke(cli, ["update", "--silent"])
+    assert result.exit_code == 0
+    fm.assert_called_once_with("devel")
+    dr.assert_called_once_with("devel", manifest)
+
+
+def test_update_dev_build_is_not_updatable():
+    """A feature-branch (dev.*) build refuses to auto-update."""
+    with (
+        patch("riocli.bootstrap.__version__", "10.6.0-dev.feature-x+sha"),
+        patch("riocli.bootstrap.is_pip_installation", return_value=False),
+        patch("riocli.bootstrap.appimage.fetch_manifest") as fm,
+    ):
+        result = CliRunner().invoke(cli, ["update", "--silent"])
+    assert result.exit_code == 0
+    assert "development build" in result.output.lower()
+    fm.assert_not_called()

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -22,12 +22,12 @@ from riocli.bootstrap import cli
 def test_update_devel_appimage_uses_blob():
     """A devel AppImage runs the blob path, not the GitHub path."""
     manifest = {
-        "version": "10.9.9-devel+newsha",
-        "file": "rio-10.9.9-devel+newsha-x86_64.AppImage",
+        "version": "10.9.9+devel.newsha",
+        "file": "rio-10.9.9-x86_64.AppImage",
         "sha256": "x",
     }
     with (
-        patch("riocli.bootstrap.__version__", "10.6.0-devel+oldsha"),
+        patch("riocli.bootstrap.__version__", "10.6.0+devel.oldsha"),
         patch("riocli.bootstrap.is_pip_installation", return_value=False),
         patch("riocli.bootstrap.appimage.fetch_manifest", return_value=manifest) as fm,
         patch("riocli.bootstrap.appimage.download_and_replace") as dr,
@@ -55,7 +55,7 @@ def test_update_appimage_already_latest():
 def test_update_dev_build_is_not_updatable():
     """A feature-branch (dev.*) build refuses to auto-update."""
     with (
-        patch("riocli.bootstrap.__version__", "10.6.0-dev.feature-x+sha"),
+        patch("riocli.bootstrap.__version__", "10.6.0+dev.feature-x.sha"),
         patch("riocli.bootstrap.is_pip_installation", return_value=False),
         patch("riocli.bootstrap.appimage.fetch_manifest") as fm,
     ):

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -38,6 +38,20 @@ def test_update_devel_appimage_uses_blob():
     dr.assert_called_once_with("devel", manifest)
 
 
+def test_update_appimage_already_latest():
+    manifest = {"version": "10.6.0", "file": "rio-10.6.0-x86_64.AppImage", "sha256": "x"}
+    with (
+        patch("riocli.bootstrap.__version__", "10.6.0"),
+        patch("riocli.bootstrap.is_pip_installation", return_value=False),
+        patch("riocli.bootstrap.appimage.fetch_manifest", return_value=manifest),
+        patch("riocli.bootstrap.appimage.download_and_replace") as dr,
+    ):
+        result = CliRunner().invoke(cli, ["update", "--silent"])
+    assert result.exit_code == 0
+    assert "latest version" in result.output
+    dr.assert_not_called()
+
+
 def test_update_dev_build_is_not_updatable():
     """A feature-branch (dev.*) build refuses to auto-update."""
     with (

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -19,8 +19,10 @@ from click.testing import CliRunner
 from riocli.bootstrap import cli
 
 
-def test_update_devel_appimage_uses_blob():
-    """A devel AppImage runs the blob path, not the GitHub path."""
+def test_update_devel_appimage_uses_blob(monkeypatch):
+    """A devel AppImage (APPIMAGE env set) updates from the blob, replacing
+    the AppImage file (not sys.executable)."""
+    monkeypatch.setenv("APPIMAGE", "/opt/rio.AppImage")
     manifest = {
         "version": "10.9.9+devel.newsha",
         "file": "rio-10.9.9-x86_64.AppImage",
@@ -28,21 +30,20 @@ def test_update_devel_appimage_uses_blob():
     }
     with (
         patch("riocli.bootstrap.__version__", "10.6.0+devel.oldsha"),
-        patch("riocli.bootstrap.is_pip_installation", return_value=False),
         patch("riocli.bootstrap.appimage.fetch_manifest", return_value=manifest) as fm,
         patch("riocli.bootstrap.appimage.download_and_replace") as dr,
     ):
         result = CliRunner().invoke(cli, ["update", "--silent"])
     assert result.exit_code == 0
     fm.assert_called_once_with("devel")
-    dr.assert_called_once_with("devel", manifest)
+    dr.assert_called_once_with("devel", manifest, target="/opt/rio.AppImage")
 
 
-def test_update_appimage_already_latest():
+def test_update_appimage_already_latest(monkeypatch):
+    monkeypatch.setenv("APPIMAGE", "/opt/rio.AppImage")
     manifest = {"version": "10.6.0", "file": "rio-10.6.0-x86_64.AppImage", "sha256": "x"}
     with (
         patch("riocli.bootstrap.__version__", "10.6.0"),
-        patch("riocli.bootstrap.is_pip_installation", return_value=False),
         patch("riocli.bootstrap.appimage.fetch_manifest", return_value=manifest),
         patch("riocli.bootstrap.appimage.download_and_replace") as dr,
     ):
@@ -52,14 +53,30 @@ def test_update_appimage_already_latest():
     dr.assert_not_called()
 
 
-def test_update_dev_build_is_not_updatable():
-    """A feature-branch (dev.*) build refuses to auto-update."""
+def test_update_dev_build_is_not_updatable(monkeypatch):
+    """A feature-branch (dev.*) AppImage build refuses to auto-update."""
+    monkeypatch.setenv("APPIMAGE", "/opt/rio.AppImage")
     with (
         patch("riocli.bootstrap.__version__", "10.6.0+dev.feature-x.sha"),
-        patch("riocli.bootstrap.is_pip_installation", return_value=False),
         patch("riocli.bootstrap.appimage.fetch_manifest") as fm,
     ):
         result = CliRunner().invoke(cli, ["update", "--silent"])
     assert result.exit_code == 0
     assert "development build" in result.output.lower()
+    fm.assert_not_called()
+
+
+def test_update_pip_install_uses_pypi(monkeypatch):
+    """Without APPIMAGE env it is a pip install: uses PyPI, never the blob."""
+    monkeypatch.delenv("APPIMAGE", raising=False)
+    with (
+        patch("riocli.bootstrap.__version__", "10.6.0"),
+        patch("riocli.bootstrap.check_for_updates", return_value=(True, "10.7.0")) as cfu,
+        patch("riocli.bootstrap.pip_install_cli") as pip,
+        patch("riocli.bootstrap.appimage.fetch_manifest") as fm,
+    ):
+        result = CliRunner().invoke(cli, ["update", "--silent"])
+    assert result.exit_code == 0
+    cfu.assert_called_once()
+    pip.assert_called_once()
     fm.assert_not_called()

--- a/tests/unit/utils/test_appimage.py
+++ b/tests/unit/utils/test_appimage.py
@@ -99,6 +99,10 @@ def _fake_response(content=b"", json_data=None):
     resp = MagicMock()
     resp.content = content
     resp.raise_for_status = MagicMock()
+    # Support the streaming download: `with requests.get(...) as r: r.iter_content(...)`
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    resp.iter_content = lambda chunk_size=8192: iter([content])
     if json_data is not None:
         resp.json = MagicMock(return_value=json_data)
     return resp
@@ -110,6 +114,17 @@ def test_fetch_manifest(monkeypatch):
         appimage.requests, "get", lambda url, **kw: _fake_response(json_data=manifest)
     )
     assert appimage.fetch_manifest("devel") == manifest
+
+
+def test_fetch_manifest_rejects_malformed(monkeypatch):
+    # missing 'file' and 'sha256' -> clear ValueError, not a downstream KeyError
+    monkeypatch.setattr(
+        appimage.requests,
+        "get",
+        lambda url, **kw: _fake_response(json_data={"version": "10.6.0"}),
+    )
+    with pytest.raises(ValueError, match="[Mm]alformed manifest"):
+        appimage.fetch_manifest("devel")
 
 
 def test_download_and_replace_writes_target(monkeypatch, tmp_path):

--- a/tests/unit/utils/test_appimage.py
+++ b/tests/unit/utils/test_appimage.py
@@ -75,3 +75,50 @@ def test_update_available_devel_same():
     assert appimage.update_available(
         "devel", "10.6.0-devel+aaa1111", "10.6.0-devel+aaa1111"
     ) is False
+
+
+from hashlib import sha256
+from unittest.mock import MagicMock
+
+
+def _fake_response(content=b"", json_data=None):
+    resp = MagicMock()
+    resp.content = content
+    resp.raise_for_status = MagicMock()
+    if json_data is not None:
+        resp.json = MagicMock(return_value=json_data)
+    return resp
+
+
+def test_fetch_manifest(monkeypatch):
+    manifest = {"version": "10.6.0-devel+abc", "file": "rio.AppImage", "sha256": "x"}
+    monkeypatch.setattr(
+        appimage.requests, "get", lambda url, **kw: _fake_response(json_data=manifest)
+    )
+    assert appimage.fetch_manifest("devel") == manifest
+
+
+def test_download_and_replace_writes_target(monkeypatch, tmp_path):
+    payload = b"APPIMAGE-BYTES"
+    digest = sha256(payload).hexdigest()
+    manifest = {"version": "10.6.0", "file": "rio.AppImage", "sha256": digest}
+    monkeypatch.setattr(
+        appimage.requests, "get", lambda url, **kw: _fake_response(content=payload)
+    )
+    target = tmp_path / "rio"
+    target.write_bytes(b"OLD")
+    appimage.download_and_replace("release", manifest, target=str(target))
+    assert target.read_bytes() == payload
+
+
+def test_download_and_replace_checksum_mismatch(monkeypatch, tmp_path):
+    manifest = {"version": "10.6.0", "file": "rio.AppImage", "sha256": "deadbeef"}
+    monkeypatch.setattr(
+        appimage.requests, "get", lambda url, **kw: _fake_response(content=b"bytes")
+    )
+    target = tmp_path / "rio"
+    target.write_bytes(b"OLD")
+    with pytest.raises(Exception, match="[Cc]hecksum"):
+        appimage.download_and_replace("release", manifest, target=str(target))
+    # original must be untouched on mismatch
+    assert target.read_bytes() == b"OLD"

--- a/tests/unit/utils/test_appimage.py
+++ b/tests/unit/utils/test_appimage.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from hashlib import sha256
+from unittest.mock import MagicMock
+
 import pytest
 
 from riocli.utils import appimage
@@ -66,19 +69,17 @@ def test_update_available_release_older_is_false():
 def test_update_available_devel_differs():
     # devel builds differ only by +build metadata, which semver ignores;
     # any difference in the full version string means a newer commit.
-    assert appimage.update_available(
-        "devel", "10.6.0-devel+bbb2222", "10.6.0-devel+aaa1111"
-    ) is True
+    assert (
+        appimage.update_available("devel", "10.6.0-devel+bbb2222", "10.6.0-devel+aaa1111")
+        is True
+    )
 
 
 def test_update_available_devel_same():
-    assert appimage.update_available(
-        "devel", "10.6.0-devel+aaa1111", "10.6.0-devel+aaa1111"
-    ) is False
-
-
-from hashlib import sha256
-from unittest.mock import MagicMock
+    assert (
+        appimage.update_available("devel", "10.6.0-devel+aaa1111", "10.6.0-devel+aaa1111")
+        is False
+    )
 
 
 def _fake_response(content=b"", json_data=None):

--- a/tests/unit/utils/test_appimage.py
+++ b/tests/unit/utils/test_appimage.py
@@ -48,3 +48,30 @@ def test_base_url_env_override(monkeypatch):
     assert appimage.manifest_url("devel") == (
         "https://staging.example.com/devel/latest.json"
     )
+
+
+def test_update_available_release_newer():
+    assert appimage.update_available("release", "10.7.0", "10.6.0") is True
+
+
+def test_update_available_release_same():
+    assert appimage.update_available("release", "10.6.0", "10.6.0") is False
+
+
+def test_update_available_release_older_is_false():
+    # never offer a downgrade on the release channel
+    assert appimage.update_available("release", "10.5.0", "10.6.0") is False
+
+
+def test_update_available_devel_differs():
+    # devel builds differ only by +build metadata, which semver ignores;
+    # any difference in the full version string means a newer commit.
+    assert appimage.update_available(
+        "devel", "10.6.0-devel+bbb2222", "10.6.0-devel+aaa1111"
+    ) is True
+
+
+def test_update_available_devel_same():
+    assert appimage.update_available(
+        "devel", "10.6.0-devel+aaa1111", "10.6.0-devel+aaa1111"
+    ) is False

--- a/tests/unit/utils/test_appimage.py
+++ b/tests/unit/utils/test_appimage.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from riocli.utils import appimage
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("10.6.0", appimage.CHANNEL_RELEASE),
+        ("10.6.0-devel+abc1234", appimage.CHANNEL_DEVEL),
+        ("10.6.0-devel.3+abc1234", appimage.CHANNEL_DEVEL),
+        ("10.6.0-dev.feature-x+abc1234", None),
+        ("10.6.0-rc.1+abc1234", None),
+    ],
+)
+def test_channel_for_version(version, expected):
+    assert appimage.channel_for_version(version) == expected
+
+
+def test_manifest_url_default_account():
+    assert appimage.manifest_url("devel") == (
+        f"{appimage.DEFAULT_ACCOUNT_URL}/devel/latest.json"
+    )
+
+
+def test_appimage_url_default_account():
+    assert appimage.appimage_url("release", "rio-10.6.0-x86_64.AppImage") == (
+        f"{appimage.DEFAULT_ACCOUNT_URL}/release/rio-10.6.0-x86_64.AppImage"
+    )
+
+
+def test_base_url_env_override(monkeypatch):
+    monkeypatch.setenv("RIO_APPIMAGE_BASE_URL", "https://staging.example.com")
+    assert appimage.manifest_url("devel") == (
+        "https://staging.example.com/devel/latest.json"
+    )

--- a/tests/unit/utils/test_appimage.py
+++ b/tests/unit/utils/test_appimage.py
@@ -24,10 +24,10 @@ from riocli.utils import appimage
     "version,expected",
     [
         ("10.6.0", appimage.CHANNEL_RELEASE),
-        ("10.6.0-devel+abc1234", appimage.CHANNEL_DEVEL),
-        ("10.6.0-devel.3+abc1234", appimage.CHANNEL_DEVEL),
-        ("10.6.0-dev.feature-x+abc1234", None),
-        ("10.6.0-rc.1+abc1234", None),
+        ("10.6.0+devel.abc1234", appimage.CHANNEL_DEVEL),
+        ("10.6.0+devel.3.abc1234", appimage.CHANNEL_DEVEL),
+        ("10.6.0+dev.feature-x.abc1234", None),
+        ("10.6.0+rc.1.abc1234", None),
     ],
 )
 def test_channel_for_version(version, expected):
@@ -75,14 +75,14 @@ def test_update_available_devel_differs():
     # devel builds differ only by +build metadata, which semver ignores;
     # any difference in the full version string means a newer commit.
     assert (
-        appimage.update_available("devel", "10.6.0-devel+bbb2222", "10.6.0-devel+aaa1111")
+        appimage.update_available("devel", "10.6.0+devel.bbb2222", "10.6.0+devel.aaa1111")
         is True
     )
 
 
 def test_update_available_devel_same():
     assert (
-        appimage.update_available("devel", "10.6.0-devel+aaa1111", "10.6.0-devel+aaa1111")
+        appimage.update_available("devel", "10.6.0+devel.aaa1111", "10.6.0+devel.aaa1111")
         is False
     )
 
@@ -90,7 +90,7 @@ def test_update_available_devel_same():
 def test_update_available_devel_no_downgrade():
     # remote base version older than current → no update even on devel
     assert (
-        appimage.update_available("devel", "10.5.0-devel+aaa1111", "10.6.0-devel+bbb2222")
+        appimage.update_available("devel", "10.5.0+devel.aaa1111", "10.6.0+devel.bbb2222")
         is False
     )
 
@@ -105,7 +105,7 @@ def _fake_response(content=b"", json_data=None):
 
 
 def test_fetch_manifest(monkeypatch):
-    manifest = {"version": "10.6.0-devel+abc", "file": "rio.AppImage", "sha256": "x"}
+    manifest = {"version": "10.6.0+devel.abc", "file": "rio.AppImage", "sha256": "x"}
     monkeypatch.setattr(
         appimage.requests, "get", lambda url, **kw: _fake_response(json_data=manifest)
     )

--- a/tests/unit/utils/test_appimage.py
+++ b/tests/unit/utils/test_appimage.py
@@ -34,6 +34,11 @@ def test_channel_for_version(version, expected):
     assert appimage.channel_for_version(version) == expected
 
 
+def test_channel_for_version_invalid():
+    with pytest.raises(ValueError):
+        appimage.channel_for_version("notaversion")
+
+
 def test_manifest_url_default_account():
     assert appimage.manifest_url("devel") == (
         f"{appimage.DEFAULT_ACCOUNT_URL}/devel/latest.json"
@@ -82,6 +87,14 @@ def test_update_available_devel_same():
     )
 
 
+def test_update_available_devel_no_downgrade():
+    # remote base version older than current → no update even on devel
+    assert (
+        appimage.update_available("devel", "10.5.0-devel+aaa1111", "10.6.0-devel+bbb2222")
+        is False
+    )
+
+
 def _fake_response(content=b"", json_data=None):
     resp = MagicMock()
     resp.content = content
@@ -110,6 +123,20 @@ def test_download_and_replace_writes_target(monkeypatch, tmp_path):
     target.write_bytes(b"OLD")
     appimage.download_and_replace("release", manifest, target=str(target))
     assert target.read_bytes() == payload
+
+
+def test_download_and_replace_missing_sha256(monkeypatch, tmp_path):
+    # manifest without sha256 must raise ValueError and leave target untouched
+    payload = b"APPIMAGE-BYTES"
+    manifest = {"version": "10.6.0", "file": "rio.AppImage"}
+    monkeypatch.setattr(
+        appimage.requests, "get", lambda url, **kw: _fake_response(content=payload)
+    )
+    target = tmp_path / "rio"
+    target.write_bytes(b"OLD")
+    with pytest.raises(ValueError, match="sha256"):
+        appimage.download_and_replace("release", manifest, target=str(target))
+    assert target.read_bytes() == b"OLD"
 
 
 def test_download_and_replace_checksum_mismatch(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

`rio update` fails on AppImage installs with `Failed to retrieve the download URL for the latest AppImage`. Root cause (per [Slack thread](https://rapyuta-robotics.slack.com/archives/CBAP39MGD/p1781061285374049)): the updater calls `api.github.com/.../releases/latest`, which is unauthenticated and shares the office-IP GitHub rate-limit budget. When exhausted, the asset lookup returns nothing and the download fails. Multiple users hit this.

## What changed

Move the AppImage `rio update` download path off `api.github.com` onto our own **public-read Azure Blob** containers, channel-keyed by the running binary's `__version__`. The pip/PyPI path is **untouched** — blob storage is only used in the AppImage branch.

**Consumer (CLI):**
- New focused module `riocli/utils/appimage.py`: channel detection from version suffix, manifest/URL builders, channel-aware update check, manifest fetch, and an **atomic** download→verify→swap (`os.replace`, sha256 required, request timeouts, no devel downgrade).
- `rio update` (`riocli/bootstrap.py`) now branches: pip → existing PyPI flow (unchanged); AppImage → Azure Blob channel. Development builds (`-dev.<branch>`) are reported as not auto-updatable.
- Removed the old GitHub-API-based `update_appimage` from `riocli/utils/__init__.py`.

**Producer (CI):**
- `scripts/build-rio-appimage.sh` stamps a channel suffix into `__version__` for non-release builds and uploads the AppImage + a `latest.json` manifest to the matching container via azcopy (SAS masked under `set -x`).
- `upload-appimage.yml`: drops the `main` trigger, sets `CHANNEL` (PR → `dev`, devel push → `devel`), and comments the blob URL on PRs.
- `release.yml`: passes `CHANNEL=release`. GitHub Release asset + PyPI publish are **kept** (transition fallback for already-installed binaries).

**Channels / containers** (account `riocliartifacts`, OKD4 Prod, anonymous read):

| Version pattern | Channel | Container | Retention |
|---|---|---|---|
| `X.Y.Z` | release | `release` | permanent |
| `X.Y.Z-devel+<sha>` | devel | `devel` | 30d |
| `X.Y.Z-dev.<branch>+<sha>` | (not auto-updatable) | `dev` | 15d |

Override the base URL with `RIO_APPIMAGE_BASE_URL` for staging. Details in `docs/update-channels.md`.

## Infra (already provisioned)

Storage account `riocliartifacts` (RG `rio-cli`, japaneast) with public-read `release`/`devel`/`dev` containers, lifecycle policies, and a write SAS in repo secrets `AZURE_STORAGE_ACCOUNT` / `AZURE_SAS_TOKEN` (SAS expires 2027-06-14 — rotate before then).

## Test plan

- [x] 170 unit tests pass (`uv run pytest tests/unit/`), ruff clean
- [x] Live end-to-end smoke vs the real `devel` container: anonymous manifest fetch + sha256 verify + atomic swap into a temp target (cleaned up)
- [ ] This PR's `upload-appimage.yml` run uploads to the `dev` container and comments the blob link (validates the producer path live)
- [ ] After merge to `devel`: confirm a `devel`-channel AppImage updates from the `devel` container

🤖 Generated with [Claude Code](https://claude.com/claude-code)