### PR TITLE
feat(database): Phase 1 — Database CLI commands and apply support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,3 +202,6 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning",
 ]
+
+[tool.uv.sources]
+rapyuta-io-sdk-v2 = { git = "https://github.com/rapyuta-robotics/rapyuta-io-sdk-v2", branch = "feat/database" }

--- a/riocli/apply/manifests/database.yaml
+++ b/riocli/apply/manifests/database.yaml
@@ -1,0 +1,23 @@
+apiVersion: "api.rapyuta.io/v2"
+kind: "Database"
+metadata:
+  name: "orders-db"
+  labels:
+    app: orders
+spec:
+  type: postgres
+  postgres:
+    version: "17"  # Supported: 14, 15, 16, 17, 18
+    primary:
+      deviceName: edge-node-01
+      dataDirectory: /opt/rapyuta/volumes/orders-db
+      port: 5432
+    credentials:
+      username: app
+      password: <secret>  # Immutable after creation
+    multipleDatabase:
+      - orders
+      - analytics
+    parameters:
+      max_connections: "200"
+      shared_buffers: 512MB

--- a/riocli/apply/util.py
+++ b/riocli/apply/util.py
@@ -27,6 +27,7 @@ from riocli.apply.filters import get_interface_ip, getenv
 from riocli.config import get_config_from_context
 from riocli.constants import Colors
 from riocli.constants.symbols import Symbols
+from riocli.database.model import Database
 from riocli.deployment.model import Deployment
 from riocli.device.model import Device
 from riocli.disk.model import Disk
@@ -42,6 +43,7 @@ from riocli.usergroup.model import UserGroup
 from riocli.utils import tabulate_data
 
 KIND_TO_CLASS = {
+    "database": Database,
     "deployment": Deployment,
     "device": Device,
     "disk": Disk,

--- a/riocli/bootstrap.py
+++ b/riocli/bootstrap.py
@@ -31,6 +31,7 @@ from riocli.config import Configuration
 from riocli.config.context import cli_context
 from riocli.configtree import config_trees
 from riocli.constants import Colors, Symbols
+from riocli.database import database
 from riocli.deployment import deployment
 from riocli.device import device
 from riocli.disk import disk
@@ -165,6 +166,7 @@ cli.add_command(static_route)
 cli.add_command(network)
 cli.add_command(completion)
 cli.add_command(parameter)
+cli.add_command(database)
 cli.add_command(disk)
 cli.add_command(shell)
 cli.add_command(deprecated_repl)

--- a/riocli/database/__init__.py
+++ b/riocli/database/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2025 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+from riocli.constants import Colors
+from riocli.database.delete import delete_database
+from riocli.database.inspect import inspect_database
+from riocli.database.list import list_databases
+from riocli.utils import AliasedGroup
+
+
+@click.group(
+    invoke_without_command=False,
+    cls=AliasedGroup,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+def database() -> None:
+    """Manage PostgreSQL databases.
+
+    Create, list, inspect, and delete managed databases.
+    Use ``rio apply`` to create or update databases from a manifest file.
+    """
+    pass
+
+
+database.add_command(list_databases)
+database.add_command(inspect_database)
+database.add_command(delete_database)

--- a/riocli/database/delete.py
+++ b/riocli/database/delete.py
@@ -1,0 +1,154 @@
+# Copyright 2025 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from queue import Queue
+
+import click
+from click_help_colors import HelpColorsCommand
+from rapyuta_io_sdk_v2 import Client
+from yaspin.api import Yaspin
+
+from riocli.config import new_v2_client
+from riocli.constants import Colors, Symbols
+from riocli.database.model import Database
+from riocli.database.util import display_database_list, fetch_databases
+from riocli.utils import tabulate_data
+from riocli.utils.execute import apply_func_with_result
+from riocli.utils.spinner import with_spinner
+
+
+@click.command(
+    "delete",
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+@click.option(
+    "--force", "-f", is_flag=True, default=False, help="Skip confirmation", type=bool
+)
+@click.option(
+    "-a",
+    "--all",
+    "delete_all",
+    is_flag=True,
+    default=False,
+    help="Delete all databases in the project",
+)
+@click.option(
+    "--workers",
+    "-w",
+    help="Number of parallel workers while deleting databases. Defaults to 10",
+    type=int,
+    default=10,
+)
+@click.argument("database-name-or-regex", type=str, default="")
+@with_spinner(text="Deleting database...")
+def delete_database(
+    force: bool,
+    database_name_or_regex: str,
+    delete_all: bool = False,
+    workers: int = 10,
+    spinner: Yaspin = None,
+) -> None:
+    """Delete one or more databases with a name or regex pattern.
+
+    Usage Examples:
+
+        Delete a database by name
+
+            $ rio database delete orders-db
+
+        Delete without confirmation
+
+            $ rio database delete orders-db --force
+
+        Delete all databases in the project
+
+            $ rio database delete --all
+
+        Delete databases using a regex pattern
+
+            $ rio database delete "orders.*"
+    """
+    client = new_v2_client()
+
+    if not (database_name_or_regex or delete_all):
+        spinner.text = "Nothing to delete"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
+
+    try:
+        databases = fetch_databases(client, database_name_or_regex, delete_all)
+    except Exception as e:
+        spinner.text = click.style(f"Failed to find database(s): {e}", Colors.RED)
+        spinner.red.fail(Symbols.ERROR)
+        raise SystemExit(1) from e
+
+    if not databases:
+        spinner.text = "Database(s) not found"
+        spinner.green.ok(Symbols.SUCCESS)
+        return
+
+    with spinner.hidden():
+        display_database_list(databases)
+
+    spinner.write("")
+
+    if not force:
+        with spinner.hidden():
+            click.confirm(
+                "Do you want to delete the above database(s)?", default=True, abort=True
+            )
+
+    try:
+        f = functools.partial(_apply_delete, client)
+        result = apply_func_with_result(
+            f=f, items=databases, workers=workers, key=lambda x: x[0]
+        )
+        data, statuses = [], []
+        for name, status, msg in result:
+            fg = Colors.GREEN if status else Colors.RED
+            icon = Symbols.SUCCESS if status else Symbols.ERROR
+
+            statuses.append(status)
+            data.append([click.style(name, fg), click.style(f"{icon}  {msg}", fg)])
+
+        with spinner.hidden():
+            tabulate_data(data, headers=["Name", "Status"])
+
+        if not any(statuses):
+            spinner.write("")
+            spinner.text = click.style("Failed to delete database(s).", Colors.RED)
+            spinner.red.fail(Symbols.ERROR)
+            raise SystemExit(1)
+
+        icon = Symbols.SUCCESS if all(statuses) else Symbols.WARNING
+        fg = Colors.GREEN if all(statuses) else Colors.YELLOW
+        text = "successfully" if all(statuses) else "partially"
+
+        spinner.text = click.style(f"Database(s) deleted {text}.", fg)
+        spinner.ok(click.style(icon, fg))
+    except Exception as e:
+        spinner.text = click.style(f"Failed to delete database(s): {e}", Colors.RED)
+        spinner.red.fail(Symbols.ERROR)
+        raise SystemExit(1) from e
+
+
+def _apply_delete(client: Client, result: Queue, database: Database) -> None:
+    try:
+        client.delete_database(name=database.metadata.name)
+        result.put((database.metadata.name, True, "Database deleted successfully"))
+    except Exception as e:
+        result.put((database.metadata.name, False, str(e)))

--- a/riocli/database/inspect.py
+++ b/riocli/database/inspect.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from click_help_colors import HelpColorsCommand
+
+from riocli.config import new_v2_client
+from riocli.constants import Colors
+from riocli.utils import inspect_with_format
+
+
+@click.command(
+    "inspect",
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+@click.option(
+    "--format",
+    "-f",
+    "format_type",
+    default="yaml",
+    type=click.Choice(["json", "yaml"], case_sensitive=False),
+)
+@click.argument("database-name", type=str)
+def inspect_database(format_type: str, database_name: str) -> None:
+    """Inspect a database.
+
+    Usage Examples:
+
+        $ rio database inspect orders-db
+
+        $ rio database inspect orders-db --format json
+    """
+    try:
+        client = new_v2_client()
+        database = client.get_database(database_name)
+        inspect_with_format(
+            database.model_dump(exclude_none=True, by_alias=True), format_type
+        )
+    except Exception as e:
+        click.secho(str(e), fg=Colors.RED)
+        raise SystemExit(1) from e

--- a/riocli/database/list.py
+++ b/riocli/database/list.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from click_help_colors import HelpColorsCommand
+
+from riocli.config import new_v2_client
+from riocli.constants import Colors
+from riocli.database.util import display_database_list
+
+
+@click.command(
+    "list",
+    cls=HelpColorsCommand,
+    help_headers_color=Colors.YELLOW,
+    help_options_color=Colors.GREEN,
+)
+@click.option(
+    "--label",
+    "-l",
+    "labels",
+    multiple=True,
+    type=click.STRING,
+    default=(),
+    help="Filter the database list by labels",
+)
+def list_databases(labels: list[str]) -> None:
+    """List the databases in the current project.
+
+    Usage Examples:
+
+        $ rio database list
+
+        $ rio database list -l app=orders
+    """
+    try:
+        client = new_v2_client(with_project=True)
+        databases = client.list_databases(label_selector=labels)
+        display_database_list(databases.items, show_header=True)
+    except Exception as e:
+        click.secho(str(e), fg=Colors.RED)
+        raise SystemExit(1) from e

--- a/riocli/database/model.py
+++ b/riocli/database/model.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rapyuta_io_sdk_v2 import Client as v2Client
+from rapyuta_io_sdk_v2 import Database as DatabaseModel
+from typing_extensions import override
+
+from riocli.model import Model
+
+
+class Database(Model):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.update(*args, **kwargs)
+        self._obj = DatabaseModel.model_validate(self)
+
+    @override
+    def create_object(
+        self, v2_client: v2Client, retry_count: int, retry_interval: int, *args, **kwargs
+    ) -> DatabaseModel:
+        return v2_client.create_database(body=self._obj)  # pyright:ignore[reportArgumentType]
+
+    @override
+    def update_object(
+        self, v2_client: v2Client, retry_count: int, retry_interval: int, *args, **kwargs
+    ) -> DatabaseModel:
+        return v2_client.update_database(name=self._obj.metadata.name, body=self._obj)  # pyright:ignore[reportArgumentType]
+
+    @override
+    def delete_object(self, v2_client: v2Client, *args, **kwargs) -> None:
+        _ = v2_client.delete_database(self._obj.metadata.name)
+
+    @override
+    def list_dependencies(self) -> list[str] | None:
+        return None

--- a/riocli/database/util.py
+++ b/riocli/database/util.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Rapyuta Robotics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import typing
+
+from rapyuta_io_sdk_v2 import Client
+
+from riocli.utils import tabulate_data
+
+_TERMINAL_PHASES = {"Running", "Failed", "Degraded"}
+
+
+def fetch_databases(
+    client: Client,
+    database_name_or_regex: str,
+    include_all: bool,
+) -> list:
+    databases = client.list_databases()
+
+    if include_all:
+        return databases.items
+
+    result = []
+    for db in databases.items:
+        if re.search(database_name_or_regex, db.metadata.name):
+            result.append(db)
+
+    return result
+
+
+def display_database_list(databases: typing.Any, show_header: bool = True):
+    headers = []
+    if show_header:
+        headers = ("GUID", "Name", "Phase", "Device", "Version")
+
+    data = []
+    for db in databases:
+        phase = getattr(db.status, "phase", None) if db.status else None
+        primary = None
+        version = None
+        if db.spec.postgres:
+            primary = db.spec.postgres.primary.device_name
+            version = db.spec.postgres.version
+        data.append(
+            [
+                db.metadata.guid,
+                db.metadata.name,
+                phase or "Unknown",
+                primary or "-",
+                version or "-",
+            ]
+        )
+
+    tabulate_data(data, headers)

--- a/uv.lock
+++ b/uv.lock
@@ -1609,7 +1609,7 @@ requires-dist = [
     { name = "pytz" },
     { name = "pyyaml", specifier = ">=5.4.1" },
     { name = "rapyuta-io", specifier = ">=3.1.0" },
-    { name = "rapyuta-io-sdk-v2", specifier = ">=0.8.0" },
+    { name = "rapyuta-io-sdk-v2", git = "https://github.com/rapyuta-robotics/rapyuta-io-sdk-v2?branch=feat%2Fdatabase" },
     { name = "requests", specifier = ">=2.20.0" },
     { name = "semver", specifier = ">=3.0.0" },
     { name = "setuptools" },
@@ -1636,17 +1636,13 @@ dev = [
 
 [[package]]
 name = "rapyuta-io-sdk-v2"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.0"
+source = { git = "https://github.com/rapyuta-robotics/rapyuta-io-sdk-v2?branch=feat%2Fdatabase#1d1f4bea5d94d7bffdfce97dd4a144ea94eae185" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "python-benedict" },
     { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/76/c954ada6d7c2967bd36f87ff248cd0547ac94b860094a7d63bde26df3b61/rapyuta_io_sdk_v2-0.8.0.tar.gz", hash = "sha256:360ef1f37da71e490d3ef3880534c52c2a25f0b3df9236dbd3b78ed0dca4229e", size = 139036, upload-time = "2026-06-03T12:59:09.758Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/18/15d22456044aa45b947c9fbf4dd7c3d8c8adcf143a9e1affbb6f037b1439/rapyuta_io_sdk_v2-0.8.0-py3-none-any.whl", hash = "sha256:c1cab733f350bbd64f50ff34dbde59f2c4c7a316a6aaeac0e3a6f1438a91a0bf", size = 60232, upload-time = "2026-06-03T12:59:08.104Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 1 of the Managed Database initiative: CLI commands for the new `Database` resource and declarative apply/delete support.

- **`riocli/database/`** — new `rio database` command group:
  - `list` — tabular output with GUID, name, phase, primary device, Postgres version; supports `--label` filtering
  - `inspect` — full YAML/JSON dump via the shared `inspect_with_format` helper
  - `delete` — single name, regex pattern, or `--all`; parallel workers; confirmation prompt
- **`riocli/database/model.py`** — `Database(Model)` subclass wiring `create_object`, `update_object`, `delete_object` for `rio apply` and `rio delete`
- **`riocli/apply/manifests/database.yaml`** — sample manifest for `rio explain database`
- **`riocli/apply/util.py`** — `"database": Database` entry in `KIND_TO_CLASS`
- **`riocli/bootstrap.py`** — `rio database` registered in the top-level CLI group

## Usage

```bash
# Declarative
rio apply -f database.yaml
rio delete -f database.yaml

# Imperative
rio database list
rio database list -l app=orders
rio database inspect orders-db
rio database inspect orders-db --format json
rio database delete orders-db
rio database delete "orders.*" --force

# Sample manifest
rio explain database
```

## Test plan

- [ ] `rio database list` prints a table with the expected columns
- [ ] `rio database inspect <name>` outputs valid YAML/JSON
- [ ] `rio database delete <name>` prompts, then deletes; `--force` skips prompt
- [ ] `rio database delete --all` deletes every database in the project
- [ ] `rio apply -f database.yaml` creates/updates a Database resource
- [ ] `rio explain database` outputs the sample manifest
- [ ] `rio list-examples` includes `database` in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)