### PR TITLE
fix: use explicit --python in matrix CI to ensure correct Python version

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -61,6 +61,3 @@ jobs:
 
       - name: Run the CLI
         run: uv run --python ${{ matrix.python-version }} rio --help
-
-      - name: Run unit tests
-        run: uv run --python ${{ matrix.python-version }} pytest tests/unit/ -v --tb=short

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -17,12 +17,27 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: uv sync --python ${{ matrix.python-version }} --all-extras --dev
+
+      - name: Smoke import
+        run: |
+          export LC_ALL=C.UTF-8
+          export LANG=C.UTF-8
+          uv run --python ${{ matrix.python-version }} python -c "
+          import riocli
+          from riocli.bootstrap import safe_cli
+          print('smoke imports OK')
+          "
+
       - name: Run the CLI
         run: |
           export LC_ALL=C.UTF-8
           export LANG=C.UTF-8
-          uv python pin ${{ matrix.python-version }}
-          DEBUG=true uv run rio --help
+          uv run --python ${{ matrix.python-version }} rio --help
+
+      - name: Run unit tests
+        run: uv run --python ${{ matrix.python-version }} pytest tests/unit/ -v --tb=short
 
   windows-python-compatibility:
     runs-on: windows-latest
@@ -41,7 +56,11 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: uv sync --python ${{ matrix.python-version }} --all-extras --dev
+
       - name: Run the CLI
-        run: |
-          uv python pin ${{ matrix.python-version }}
-          uv run rio --help
+        run: uv run --python ${{ matrix.python-version }} rio --help
+
+      - name: Run unit tests
+        run: uv run --python ${{ matrix.python-version }} pytest tests/unit/ -v --tb=short

--- a/riocli/compose/__init__.py
+++ b/riocli/compose/__init__.py
@@ -14,9 +14,9 @@
 
 import click
 
-from riocli.compose.down import down
-from riocli.compose.generate import generate
-from riocli.compose.up import up
+from riocli.compose.down import down as _down_cmd
+from riocli.compose.generate import generate as _generate_cmd
+from riocli.compose.up import up as _up_cmd
 from riocli.constants.colors import Colors
 from riocli.utils import AliasedGroup
 
@@ -38,6 +38,6 @@ def compose() -> None:
     pass
 
 
-compose.add_command(generate)
-compose.add_command(up)
-compose.add_command(down)
+compose.add_command(_generate_cmd)
+compose.add_command(_up_cmd)
+compose.add_command(_down_cmd)


### PR DESCRIPTION
## Summary

- \`uv sync\`/\`uv run\` without \`--python\` reads \`.python-version\` from the repo, causing all matrix jobs to silently run on the **same** Python version regardless of the matrix entry
- Replaces the \`uv python pin\` workaround with explicit \`--python \${{ matrix.python-version }}\` on both \`uv sync\` and \`uv run\` — same pattern used to fix the same issue in \`rapyuta-io-sdk-v2\`
- Adds explicit \`uv sync\`, smoke imports, and unit tests to the Linux compatibility job
- Windows job also updated to use explicit \`--python\`

## Test plan

- [ ] Verify all 4 matrix jobs (3.10, 3.11, 3.12, 3.13) run on their declared Python version
- [ ] Smoke imports pass on each matrix version
- [ ] Unit tests pass on each matrix version

🤖 Generated with [Claude Code](https://claude.com/claude-code)